### PR TITLE
Set better permissions 'HighTide'

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -15,7 +15,7 @@ configure_file(
   configuration: conf,
   install: true,
   install_dir: get_option('bindir'),
-  install_mode: 'r-xr--r--'
+  install_mode: 'r-xr-xr-x'
 )
 
 tidal_sources = [


### PR DESCRIPTION
'r-xr--r--' means that only the owner can run HighTide, this is on a traditional installation most likely the root user. With that change everyone will be able to run it.