### PR TITLE
Have working categories in the desktop file

### DIFF
--- a/data/io.github.nokse22.HighTide.desktop.in
+++ b/data/io.github.nokse22.HighTide.desktop.in
@@ -4,5 +4,5 @@ Exec=HighTide
 Icon=io.github.nokse22.HighTide
 Terminal=false
 Type=Application
-Categories=GTK;music;Gnome;
+Categories=GNOME;GTK;Music;Audio;AudioVideo;
 StartupNotify=true


### PR DESCRIPTION
Desktop file Categories usually start with an uppercase letter and will create errors if not. I also have set a few more that should work for HighTide