### PR TITLE
Add normalization

### DIFF
--- a/data/io.github.nokse22.HighTide.gschema.xml
+++ b/data/io.github.nokse22.HighTide.gschema.xml
@@ -32,5 +32,8 @@
 	  <key name="run-background" type="b">
       <default>false</default>
     </key>
+	  <key name="normalize" type="b">
+      <default>false</default>
+    </key>
 	</schema>
 </schemalist>

--- a/data/ui/preferences.ui
+++ b/data/ui/preferences.ui
@@ -42,6 +42,15 @@ OSS</property>
         <child>
         <object class="AdwPreferencesGroup">
           <child>
+            <object class="AdwSwitchRow" id="_normalize_row">
+              <property name="title">Normalize volume</property>
+            </object>
+          </child>
+        </object>
+      </child>
+        <child>
+        <object class="AdwPreferencesGroup">
+          <child>
             <object class="AdwSwitchRow" id="_background_row">
               <property name="title">Run in the background</property>
             </object>

--- a/src/lib/player_object.py
+++ b/src/lib/player_object.py
@@ -128,7 +128,8 @@ class PlayerObject(GObject.GObject):
         # add normalization to pipeline if set by settings
         normalization = ""
         if self.normalize:
-            normalization =  "taginject name=rgtags ! rgvolume name=rgvol ! rglimiter ! audioconvert !"
+            # the pre-amp value is set to match tidal webs volume
+            normalization =  "taginject name=rgtags ! rgvolume name=rgvol pre-amp=4.0 headroom=6.0 ! rglimiter ! audioconvert !"
 
         pipeline_str = f"queue max-size-buffers=0 max-size-time=0 max-size-bytes=0 ! {normalization} audioconvert ! audioresample ! {sink_name}"
 
@@ -180,15 +181,6 @@ class PlayerObject(GObject.GObject):
         if not tracks:
             print("No tracks found to play")
             return
-
-        if self.normalize:
-            audio_sink = self.playbin.get_property("audio-sink")
-            if audio_sink:
-                rgvol = audio_sink.get_by_name("rgvol")
-            if rgvol:
-                is_album = isinstance(thing, Album)
-                rgvol.set_property("album-mode", is_album)
-                print(f"RG Album-Mode: {is_album}")
 
 
         self._tracks_to_play = tracks[index:] + tracks[:index]

--- a/src/lib/player_object.py
+++ b/src/lib/player_object.py
@@ -132,7 +132,7 @@ class PlayerObject(GObject.GObject):
             # the pre-amp value is set to match tidal webs volume
             normalization =  f"taginject name=rgtags {self.most_recent_rg_tags} ! rgvolume name=rgvol pre-amp=4.0 headroom=6.0 ! rglimiter ! audioconvert !"
 
-        pipeline_str = f"queue max-size-buffers=0 max-size-time=0 max-size-bytes=0 ! {normalization} audioconvert ! audioresample ! {sink_name}"
+        pipeline_str = f"queue max-size-buffers=0 max-size-time=0 max-size-bytes=0 ! audioconvert ! {normalization} audioresample ! {sink_name}"
 
         try:
             audio_bin = Gst.parse_bin_from_description(pipeline_str, True)

--- a/src/lib/player_object.py
+++ b/src/lib/player_object.py
@@ -255,10 +255,8 @@ class PlayerObject(GObject.GObject):
                 rgtags = audio_sink.get_by_name("rgtags")
 
             tags = (
-                f"replaygain-track-gain={stream.track_replay_gain},"
-                f"replaygain-track-peak={stream.track_peak_amplitude},"
                 f"replaygain-album-gain={stream.album_replay_gain},"
-                f"replaygain-album-peak={stream.album_peak_amplitude},"
+                f"replaygain-album-peak={stream.album_peak_amplitude}"
             )
             if rgtags:
                 rgtags.set_property("tags", tags)

--- a/src/lib/player_object.py
+++ b/src/lib/player_object.py
@@ -67,7 +67,7 @@ class PlayerObject(GObject.GObject):
         'buffering': (GObject.SignalFlags.RUN_FIRST, None, (int,)),
     }
 
-    def __init__(self, preferred_sink=AudioSink.AUTO):
+    def __init__(self, preferred_sink=AudioSink.AUTO, normalize = False):
         GObject.GObject.__init__(self)
 
         Gst.init(None)
@@ -84,6 +84,8 @@ class PlayerObject(GObject.GObject):
             self.playbin = Gst.ElementFactory.make("playbin", "playbin")
 
         self.pipeline.add(self.playbin)
+
+        self.normalize = normalize
 
         # Configure audio sink
         self._setup_audio_sink(preferred_sink)
@@ -123,7 +125,12 @@ class PlayerObject(GObject.GObject):
 
         sink_name = sink_map.get(sink_type, 'autoaudiosink')
 
-        pipeline_str = f"queue max-size-buffers=0 max-size-time=0 max-size-bytes=0 ! audioconvert ! audioresample ! {sink_name}"
+        # add normalization to pipeline if set by settings
+        normalization = ""
+        if self.normalize:
+            normalization =  "taginject name=rgtags ! rgvolume name=rgvol ! rglimiter ! audioconvert !"
+
+        pipeline_str = f"queue max-size-buffers=0 max-size-time=0 max-size-bytes=0 ! {normalization} audioconvert ! audioresample ! {sink_name}"
 
         try:
             audio_bin = Gst.parse_bin_from_description(pipeline_str, True)
@@ -173,6 +180,16 @@ class PlayerObject(GObject.GObject):
         if not tracks:
             print("No tracks found to play")
             return
+
+        if self.normalize:
+            audio_sink = self.playbin.get_property("audio-sink")
+            if audio_sink:
+                rgvol = audio_sink.get_by_name("rgvol")
+            if rgvol:
+                is_album = isinstance(thing, Album)
+                rgvol.set_property("album-mode", is_album)
+                print(f"RG Album-Mode: {is_album}")
+
 
         self._tracks_to_play = tracks[index:] + tracks[:index]
         if not self._tracks_to_play:
@@ -238,6 +255,21 @@ class PlayerObject(GObject.GObject):
             stream = track.get_stream()
             manifest = stream.get_stream_manifest()
             urls = manifest.get_urls()
+
+            if self.normalize:
+                audio_sink = self.playbin.get_property("audio-sink")
+
+                if audio_sink:
+                    rgtags = audio_sink.get_by_name("rgtags")
+                if rgtags:
+                    tags = (
+                        f"replaygain-track-gain={stream.track_replay_gain},"
+                        f"replaygain-track-peak={stream.track_peak_amplitude},"
+                        f"replaygain-album-gain={stream.album_replay_gain},"
+                        f"replaygain-album-peak={stream.album_peak_amplitude},"
+                    )
+                    rgtags.set_property("tags", tags)
+                    print(f"Applied RG Tags: {tags}")
 
             if stream.manifest_mime_type == ManifestMimeType.MPD:
                 data = stream.get_manifest_data()

--- a/src/main.py
+++ b/src/main.py
@@ -107,6 +107,11 @@ class TidalApplication(Adw.Application):
             builder.get_object("_background_row").set_active(
                 self.win.settings.get_boolean("run-background"))
 
+            builder.get_object("_normalize_row").connect(
+                "notify::active", self.on_normalize_changed)
+            builder.get_object("_normalize_row").set_active(
+                self.win.settings.get_boolean("normalize"))
+
             self.preferences = builder.get_object("_preference_window")
 
         self.preferences.present(self.win)
@@ -119,6 +124,9 @@ class TidalApplication(Adw.Application):
 
     def on_background_changed(self, widget, *args):
         self.win.set_hide_on_close(widget.get_active())
+
+    def on_normalize_changed(self, widget, *args):
+        self.win.change_normalization(widget.get_active())
 
     def create_action(self, name, callback, shortcuts=None):
         action = Gio.SimpleAction.new(name, None)

--- a/src/window.py
+++ b/src/window.py
@@ -386,11 +386,12 @@ class HighTideWindow(Adw.ApplicationWindow):
         self.settings.set_int("preferred-sink", sink)
 
     def change_normalization(self, state):
-        self.player_object.normalize = state
-        self.settings.set_boolean("normalize", state)
-        # recreate audio pipeline, kinda dirty ngl
-        self.player_object.change_audio_sink(
-            self.settings.get_int("preferred-sink"))
+        if self.player_object.normalize != state:
+            self.player_object.normalize = state
+            self.settings.set_boolean("normalize", state)
+            # recreate audio pipeline, kinda dirty ngl
+            self.player_object.change_audio_sink(
+                self.settings.get_int("preferred-sink"))
 
     @Gtk.Template.Callback("on_track_radio_button_clicked")
     def on_track_radio_button_clicked_func(self, widget):

--- a/src/window.py
+++ b/src/window.py
@@ -92,7 +92,8 @@ class HighTideWindow(Adw.ApplicationWindow):
             "default-height", Gio.SettingsBindFlags.DEFAULT)
 
         self.player_object = PlayerObject(
-            self.settings.get_int('preferred-sink'))
+            self.settings.get_int('preferred-sink'),
+            self.settings.get_boolean('normalize'))
         variables.player_object = self.player_object
 
         self.volume_button.get_adjustment().set_value(
@@ -383,6 +384,13 @@ class HighTideWindow(Adw.ApplicationWindow):
     def change_audio_sink(self, sink):
         self.player_object.change_audio_sink(sink)
         self.settings.set_int("preferred-sink", sink)
+
+    def change_normalization(self, state):
+        self.player_object.normalize = state
+        self.settings.set_boolean("normalize", state)
+        # recreate audio pipeline, kinda dirty ngl
+        self.player_object.change_audio_sink(
+            self.settings.get_int("preferred-sink"))
 
     @Gtk.Template.Callback("on_track_radio_button_clicked")
     def on_track_radio_button_clicked_func(self, widget):


### PR DESCRIPTION
Fixes #36 
Seems to work, but I have no idea how to verify the gain values except by ear.

Caveats with this implementation:
Fall back normalization does not work, as python-tidal set the values to one by default.
When switching normalization back on, it only gets applied to the next track, since the tags are not applied to the current track.

This is my first time working with gtk and gst, so my implementation could be suboptimal.