### PR TITLE
Fix AAC display and wobbly progressbar

### DIFF
--- a/data/ui/window.blp
+++ b/data/ui/window.blp
@@ -414,6 +414,8 @@ template $HighTideWindow: Adw.ApplicationWindow {
               Box {
                 Label time_played_label {
                   label: "00:00";
+                  width-chars: 5;
+                  xalign: 0;
                 }
 
                 Scale progress_bar {
@@ -427,6 +429,8 @@ template $HighTideWindow: Adw.ApplicationWindow {
 
                 Label duration_label {
                   label: "00:00";
+                  width-chars: 5;
+                  xalign: 1;
                 }
               }
 

--- a/src/window.py
+++ b/src/window.py
@@ -285,21 +285,34 @@ class HighTideWindow(Adw.ApplicationWindow):
                 bit_depth = f"{stream.bit_depth}-bit"
             if stream.sample_rate:
                 sample_rate = f"{stream.sample_rate / 1000:.1f} kHz"
+            if stream.audio_quality:
+                match stream.audio_quality:
+                    case "LOW":
+                        bitrate = "96 kbps"
+                    case "HIGH":
+                        bitrate = "320 kbps"
+                    case _:
+                        bitrate = "Lossless"
 
         manifest = self.player_object.manifest
         if manifest:
             if manifest.codecs:
                 codec = manifest.codecs
+                if codec == "MP4A":
+                    codec = "AAC"
                 self.quality_label.set_visible(False)
 
         quality_text = f"{codec}"
 
         if bit_depth or sample_rate:
             quality_details = []
-            if bit_depth:
+            if bit_depth and codec != "AAC":
                 quality_details.append(bit_depth)
-            if sample_rate:
+            if sample_rate and codec != "AAC":
                 quality_details.append(sample_rate)
+            if bitrate and codec == "AAC":
+                quality_details.append(bitrate)
+
 
             if quality_details:
                 quality_text += f" ({' / '.join(quality_details)})"


### PR DESCRIPTION
I think displaying the bitrate for aac (MP4A is just the container, I believe) just makes more sense because bit depth and sample rate are constant for that codec.

Additionally, I set the time labels to occupy a fixed space because they would change the size of the progress bar every second.