### PR TITLE
Change HeaderBar policy to wide

### DIFF
--- a/data/ui/window.blp
+++ b/data/ui/window.blp
@@ -25,7 +25,7 @@ template $HighTideWindow: Adw.ApplicationWindow {
 
         content: Adw.OverlaySplitView {
           max-sidebar-width: 480;
-          min-sidebar-width: 300;
+          min-sidebar-width: 320;
           sidebar-width-fraction: 0.35;
 
           content: Adw.ToolbarView {
@@ -668,6 +668,7 @@ template $HighTideWindow: Adw.ApplicationWindow {
         Adw.HeaderBar player_headerbar {
           title-widget: Adw.ViewSwitcher {
             stack: sidebar_stack;
+            policy: wide;
           };
         }
       }


### PR DESCRIPTION
I noticed that the header bar view switcher had too tight offsets on the top and did not match the look of other gnome apps.

New:
![image](https://github.com/user-attachments/assets/8badcf9c-3571-429c-889b-cf3bbdec6d5f)

Previously:
![image](https://github.com/user-attachments/assets/66a3e042-61b5-4ed3-9ce4-e3f1e8420cf9)
