### PR TITLE
Implement "Go to album" buttons

### DIFF
--- a/data/ui/window.blp
+++ b/data/ui/window.blp
@@ -510,6 +510,18 @@ template $HighTideWindow: Adw.ApplicationWindow {
                       clicked => $on_track_radio_button_clicked();
                     }
 
+                    Button album_button {
+                      icon-name: "library-music-symbolic";
+                      tooltip-text: _("Go to album");
+                      valign: center;
+
+                      styles [
+                        "flat",
+                      ]
+
+                      clicked => $on_album_button_clicked();
+                    }
+
                     Button copy_share_link {
                       icon-name: "share-alt-symbolic";
                       tooltip-text: _("Copy Share Link");

--- a/src/widgets/generic_track_widget.py
+++ b/src/widgets/generic_track_widget.py
@@ -104,6 +104,10 @@ class HTGenericTrackWidget(Gtk.ListBoxRow, IDisconnectable):
             _("Go to track radio"),
             f"win.push-track-radio-page::{self.track.id}")
 
+        self.track_menu.prepend(
+            _("Go to album"),
+            f"win.push-album-page::{self.track.album.id}")
+
         action_entries = [
             ("play-next", self._play_next),
             ("add-to-queue", self._add_to_queue),

--- a/src/window.py
+++ b/src/window.py
@@ -426,6 +426,12 @@ class HighTideWindow(Adw.ApplicationWindow):
         page = HTHrackRadioPage(track.id).load()
         self.navigation_view.push(page)
 
+    @Gtk.Template.Callback("on_album_button_clicked")
+    def on_album_button_clicked_func(self, widget):
+        track = self.player_object.playing_track
+        page = HTAlbumPage(track.album.id).load()
+        self.navigation_view.push(page)
+
     @Gtk.Template.Callback("on_skip_forward_button_clicked")
     def on_skip_forward_button_clicked_func(self, widget):
         self.player_object.play_next()


### PR DESCRIPTION
This PR will implement the go to album buttons as requested in #51 

Player:
![image](https://github.com/user-attachments/assets/7534520b-ca20-4d3a-9a62-d8f52567e9db)


Tracklist:
![image](https://github.com/user-attachments/assets/877f84ce-a70b-4dbc-941f-5c1674ee5ff9)

The Tracklist button is mostly relevant for mobile users as the album name is displayed and clickable on desktops with sufficient window size.



