### PR TITLE
Use full_name of track if available

### DIFF
--- a/src/widgets/generic_track_widget.py
+++ b/src/widgets/generic_track_widget.py
@@ -79,7 +79,7 @@ class HTGenericTrackWidget(Gtk.ListBoxRow, IDisconnectable):
         self.track = _track
 
         self.track_album_label.set_album(self.track.album)
-        self.track_title_label.set_label(self.track.name)
+        self.track_title_label.set_label(self.track.full_name if hasattr(self.track, 'full_name') else self.track.name)
         self.artist_label.set_artists(self.track.artists)
 
         self.explicit_label.set_visible(self.track.explicit)


### PR DESCRIPTION
This fixes a bug where we would not show the version as part of the track name, unlike the TIDAL client.

Here is a demo using the album from the issue #59 
![Screenshot From 2025-05-31 21-17-38](https://github.com/user-attachments/assets/e0f08517-7e85-4a99-bf60-cb6a8db5869a)

fixes #59 