### PR TITLE
Do not default to 0 progress when current position cannot be queried

### DIFF
--- a/src/lib/player_object.py
+++ b/src/lib/player_object.py
@@ -426,10 +426,11 @@ class PlayerObject(GObject.GObject):
         success, duration = self.playbin.query_duration(Gst.Format.TIME)
         return duration if success else 0
 
-    def query_position(self):
+    def query_position(self) -> int | None:
         """Get the current playback position."""
         success, position = self.playbin.query_position(Gst.Format.TIME)
-        return position if success else 0
+        print(f"Position: {position}, Success: {success}")
+        return position if success else None
 
     def seek(self, seek_fraction):
         """Seek to a position in the current track."""

--- a/src/lib/player_object.py
+++ b/src/lib/player_object.py
@@ -114,6 +114,7 @@ class PlayerObject(GObject.GObject):
         self.can_prev = False
         self.manifest = None
         self.stream = None
+        self.update_timer = None
 
     @GObject.Property(type=bool, default=False)
     def playing(self):
@@ -260,7 +261,9 @@ class PlayerObject(GObject.GObject):
         """Start playback."""
         self.playing = True
         self.pipeline.set_state(Gst.State.PLAYING)
-        GLib.timeout_add(1000, self._update_slider_callback)
+        if self.update_timer:
+            GLib.source_remove(self.update_timer)
+        self.update_timer = GLib.timeout_add(1000, self._update_slider_callback)
 
     def pause(self):
         """Pause playback."""
@@ -429,7 +432,6 @@ class PlayerObject(GObject.GObject):
     def query_position(self) -> int | None:
         """Get the current playback position."""
         success, position = self.playbin.query_position(Gst.Format.TIME)
-        print(f"Position: {position}, Success: {success}")
         return position if success else None
 
     def seek(self, seek_fraction):

--- a/src/window.py
+++ b/src/window.py
@@ -548,9 +548,12 @@ class HighTideWindow(Adw.ApplicationWindow):
         """Called on a timer, it updates the progress bar and
             adds the song duration and position."""
         self.duration = self.player_object.query_duration()
-
         end_value = self.duration / Gst.SECOND
-        position = self.player_object.query_position() / Gst.SECOND
+
+        position = self.player_object.query_position()
+        if position is None:
+            return
+        position = position / Gst.SECOND
         fraction = 0
 
         self.lyrics_widget.set_current_line(position)


### PR DESCRIPTION
This fixes an issue where we would sometimes reset the seek bar to the start when seeking. This occurred due to a bad default value of 0 when querying playbin for the current position in the track. 

Instead of returning 0, which is a valid position, we are now returning None, which can be conditionally ignored in the seek bar update loop. This way, if we are temporarily unable to query the location from playbin, we retain the current position.

In my testing, this has eliminated the seeking bug.

This PR also fixes another issue where we would spawn technically infinite update timers to update the duration / seek bar progress as the old timer would not get cleared.

closes #17 