### PR TITLE
Fix MPRIS enough for Turntable to work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,7 @@ node_modules/
 # local flatpak build
 /repo
 /.flatpak-builder/
+/build-aux/repo
+/build-aux/.flatpak-builder/
 
 /subprojects/blueprint-compiler

--- a/src/lib/player_object.py
+++ b/src/lib/player_object.py
@@ -409,6 +409,13 @@ class PlayerObject(GObject.GObject):
         self.queue.insert(0, track)
         self.emit("song-added-to-queue")
 
+    def query_volume(self):
+        volume = self.playbin.get_property("volume")
+        if self.quadratic_volume:
+            return volume ** (1/2)
+        else:
+            return volume
+
     def change_volume(self, value):
         if self.quadratic_volume:
             self.playbin.set_property("volume", value**2)
@@ -421,6 +428,7 @@ class PlayerObject(GObject.GObject):
         self.emit("update-slider")
         duration = self.query_duration()
         if duration != self.duration:
+            self.duration = duration
             self.emit("duration-changed")
         return self.playing
 


### PR DESCRIPTION
Related: #3

- `mpris:length` is supposed to be an int64; also in microseconds
- `Position` is required for scrobblers to be able to track the playback
- `_update_slider_callback` would constantly emit `duration-changed` because in the comparison the `self.duration` was never updated (always kept at 0), Turntable would interpret any `Metadata` change as a song change (even with the same song ID which is not great but evidently works for most other players)
- `Volume` control was busted (MPRIS code out of date with the player object)..