### PR TITLE
Sync volume back from audio sink

### DIFF
--- a/src/window.py
+++ b/src/window.py
@@ -545,11 +545,12 @@ class HighTideWindow(Adw.ApplicationWindow):
         self.shuffle_button.set_active(self.player_object.shuffle)
 
     def update_slider(self, *args):
-        """Called on a timer, it updates the progress bar and
-            adds the song duration and position."""
+        """Called on a timer, it updates the progress bar,
+        adds the song duration and position, and updates the volume."""
         self.duration = self.player_object.query_duration()
         end_value = self.duration / Gst.SECOND
 
+        self.volume_button.get_adjustment().set_value(self.player_object.query_volume())
         position = self.player_object.query_position(default=None)
         if position is None:
             return


### PR DESCRIPTION
This way if an external source changes the sink volume (MPRIS, System Settings) the player's volume control will stay in sync.