### PR TITLE
Use full track name in player

### DIFF
--- a/src/window.py
+++ b/src/window.py
@@ -292,8 +292,8 @@ class HighTideWindow(Adw.ApplicationWindow):
         if track is None:
             return
 
-        self.song_title_label.set_label(track.name)
-        self.song_title_label.set_tooltip_text(track.name)
+        self.song_title_label.set_label(track.full_name if hasattr(track, 'full_name') else track.name)
+        self.song_title_label.set_tooltip_text(track.full_name if hasattr(track, 'full_name') else track.name)
         self.artist_label.set_artists(track.artists)
         self.explicit_label.set_visible(track.explicit)
 


### PR DESCRIPTION
This will ensure the player will also display the full track name rather than the short version. 