### PR TITLE
Ensure Login keyring is unlocked

### DIFF
--- a/src/lib/secret_storage.py
+++ b/src/lib/secret_storage.py
@@ -39,9 +39,14 @@ class SecretStore:
         )
 
         self.key = "high-tide-login"
+        
+        # Ensure the Login keyring is unlocked (https://github.com/Nokse22/high-tide/issues/97)
+        service = Secret.Service.get_sync(Secret.ServiceFlags.LOAD_COLLECTIONS)
+        for c in service.get_collections():
+            if c.get_label() == "Login" and c.get_locked():
+                service.unlock_sync([c])
 
         password = Secret.password_lookup_sync(self.schema, {}, None)
-
         try:
             if password:
                 json_data = json.loads(password)


### PR DESCRIPTION
Fixes #97 

We specifically check for the Login keyring and request that it will be unlocked before reading the password. I tested this on NixOS and I no longer had the issue that High Tide did not ask for an unlock.

It also does not ask to unlock when already unlocked.