### PR TITLE
Sort favorites by date added

### DIFF
--- a/build-aux/python3-tidalapi.json
+++ b/build-aux/python3-tidalapi.json
@@ -48,8 +48,8 @@
         },
         {
             "type": "file",
-            "url": "https://files.pythonhosted.org/packages/db/a6/efe5044ab4e84e945a3b84e40af3e4ff68f17de20c1fe2d58ed821b1d267/tidalapi-0.8.3-py3-none-any.whl",
-            "sha256": "b6698e308cc9f4edac4b9c1bc22773f040d4de0bbac212defcbe33a93f66b3c7"
+            "url": "https://github.com/EbbLabs/python-tidal/releases/download/v0.8.5/tidalapi-0.8.5-py3-none-any.whl",
+            "sha256": "208f9ca47d012563f7038764a44ae46d68ae38d6c2a527e15fab50f5670bda9f"
         },
         {
             "type": "file",

--- a/data/io.github.nokse22.high-tide.gschema.xml
+++ b/data/io.github.nokse22.high-tide.gschema.xml
@@ -47,5 +47,8 @@
 	  <key name="discord-rpc" type="b">
       <default>true</default>
     </key>
+    <key name="sort-favourites-by-added" type="b">
+      <default>false</default>
+    </key>
 	</schema>
 </schemalist>

--- a/data/ui/preferences.blp
+++ b/data/ui/preferences.blp
@@ -50,6 +50,9 @@ Adw.PreferencesDialog _preference_window {
       Adw.SwitchRow _discord_rpc_row {
         title: _("Enable Discord Rich Presence");
       }
+      Adw.SwitchRow _sort_favourites_by_added {
+        title: _("Sort my collection by date added");
+      }
     }
   }
 }

--- a/src/lib/player_object.py
+++ b/src/lib/player_object.py
@@ -299,7 +299,7 @@ class PlayerObject(GObject.GObject):
         elif isinstance(thing, Track):
             tracks_list = [thing]
 
-        self.id_list = [track.id for track in tracks_list]
+        self.id_list = [track.id for track in tracks_list or []]
 
         return tracks_list
 

--- a/src/lib/utils.py
+++ b/src/lib/utils.py
@@ -29,6 +29,7 @@ from tidalapi.album import Album
 from tidalapi.media import Track
 from tidalapi.playlist import Playlist
 from tidalapi.mix import Mix
+from tidalapi.types import ItemOrder, OrderDirection
 
 from ..pages import HTArtistPage
 from ..pages import HTAlbumPage
@@ -146,7 +147,7 @@ def get_mix(mix_id: str) -> Mix:
     return cache.get_mix(mix_id)
 
 
-def get_favourites() -> None:
+def get_favourites(sort_favourite_tracks=False) -> None:
     """Load all user favorites from TIDAL API and cache them globally.
 
     Retrieves and caches the user's favorite mixes, tracks, artists, albums,
@@ -164,8 +165,11 @@ def get_favourites() -> None:
 
     try:
         favourite_artists = user.favorites.artists()
-        favourite_tracks = user.favorites.tracks()
         favourite_albums = user.favorites.albums()
+        favourite_tracks = user.favorites.tracks(
+            order=ItemOrder.Date if sort_favourite_tracks else ItemOrder.Name,
+            order_direction=OrderDirection.Descending if sort_favourite_tracks else OrderDirection.Ascending,
+        )
         favourite_playlists = user.favorites.playlists()
         favourite_mixes = user.favorites.mixes()
         playlist_and_favorite_playlists = user.playlist_and_favorite_playlists()
@@ -180,6 +184,10 @@ def get_favourites() -> None:
     print(f"Favorite Mixes: {len(favourite_mixes)}")
     print(f"Playlist and Favorite Playlists: {len(playlist_and_favorite_playlists)}")
     print(f"User Playlists: {len(user_playlists)}")
+
+    # if sort_favourite_tracks:
+    #    print("Sorting favorite tracks by date_added...")
+    #    favourite_tracks.sort(key=lambda el: el.user_date_added, reverse=True)
 
 
 def is_favourited(item: Any) -> bool:

--- a/src/lib/utils.py
+++ b/src/lib/utils.py
@@ -55,6 +55,7 @@ favourite_albums: List[Album] = []
 favourite_playlists: List[Playlist] = []
 playlist_and_favorite_playlists: List[Playlist] = []
 user_playlists: List[Playlist] = []
+sort_favourites_by_added = False
 
 
 def init() -> None:
@@ -147,7 +148,7 @@ def get_mix(mix_id: str) -> Mix:
     return cache.get_mix(mix_id)
 
 
-def get_favourites(sort_favourite_tracks=False) -> None:
+def get_favourites() -> None:
     """Load all user favorites from TIDAL API and cache them globally.
 
     Retrieves and caches the user's favorite mixes, tracks, artists, albums,
@@ -160,18 +161,33 @@ def get_favourites(sort_favourite_tracks=False) -> None:
     global favourite_playlists
     global playlist_and_favorite_playlists
     global user_playlists
+    global sort_favourites_by_added
 
     user = session.user
 
+    order = ItemOrder.Date if sort_favourites_by_added else ItemOrder.Name
+    order_direction = (
+        OrderDirection.Descending
+        if sort_favourites_by_added
+        else OrderDirection.Ascending
+    )
+
     try:
-        favourite_artists = user.favorites.artists()
-        favourite_albums = user.favorites.albums()
-        favourite_tracks = user.favorites.tracks(
-            order=ItemOrder.Date if sort_favourite_tracks else ItemOrder.Name,
-            order_direction=OrderDirection.Descending if sort_favourite_tracks else OrderDirection.Ascending,
+        favourite_artists = user.favorites.artists(
+            order=order, order_direction=order_direction
         )
-        favourite_playlists = user.favorites.playlists()
-        favourite_mixes = user.favorites.mixes()
+        favourite_albums = user.favorites.albums(
+            order=order, order_direction=order_direction
+        )
+        favourite_tracks = user.favorites.tracks(
+            order=order, order_direction=order_direction
+        )
+        favourite_playlists = user.favorites.playlists(
+            order=order, order_direction=order_direction
+        )
+        favourite_mixes = user.favorites.mixes(
+            order=order, order_direction=order_direction
+        )
         playlist_and_favorite_playlists = user.playlist_and_favorite_playlists()
         user_playlists = user.playlists()
     except Exception as e:
@@ -184,10 +200,6 @@ def get_favourites(sort_favourite_tracks=False) -> None:
     print(f"Favorite Mixes: {len(favourite_mixes)}")
     print(f"Playlist and Favorite Playlists: {len(playlist_and_favorite_playlists)}")
     print(f"User Playlists: {len(user_playlists)}")
-
-    # if sort_favourite_tracks:
-    #    print("Sorting favorite tracks by date_added...")
-    #    favourite_tracks.sort(key=lambda el: el.user_date_added, reverse=True)
 
 
 def is_favourited(item: Any) -> bool:

--- a/src/main.py
+++ b/src/main.py
@@ -51,6 +51,7 @@ class HighTideApplication(Adw.Application):
         utils.init()
 
         self.settings: Gio.Settings = Gio.Settings.new("io.github.nokse22.high-tide")
+        utils.sort_favourites_by_added = self.settings.get_boolean("sort-favourites-by-added")
 
         self.preferences: Gtk.Window | None = None
 
@@ -163,6 +164,13 @@ class HighTideApplication(Adw.Application):
                 "notify::active", self.on_discord_rpc_changed
             )
 
+            builder.get_object("_sort_favourites_by_added").set_active(
+                self.settings.get_boolean("sort-favourites-by-added")
+            )
+            builder.get_object("_sort_favourites_by_added").connect(
+                "notify::active", self.on_sort_changed
+            )
+
             self.preferences = builder.get_object("_preference_window")
 
         self.preferences.present(self.win)
@@ -184,6 +192,9 @@ class HighTideApplication(Adw.Application):
 
     def on_discord_rpc_changed(self, widget: Any, *args) -> None:
         self.win.change_discord_rpc_enabled(widget.get_active())
+    
+    def on_sort_changed(self, widget: Any, *args) -> None:
+        self.win.sort_favourites_by_added_toggled(widget.get_active())
 
     def create_action(
         self, name: str, callback: Callable, shortcuts: List[str] | None = None

--- a/src/pages/artist_page.py
+++ b/src/pages/artist_page.py
@@ -39,8 +39,14 @@ class HTArtistPage(Page):
         self.albums = self.artist.get_albums(limit=10)
         self.albums_ep_singles = self.artist.get_albums_ep_singles(limit=10)
         self.albums_other = self.artist.get_albums_other(limit=10)
-        self.similar = self.artist.get_similar()
-        self.bio = self.artist.get_bio()
+
+        # tidalapi-0.8.5 breaks loading similar and bio of artists apparently
+        # self.similar = self.artist.get_similar()
+        # print('similar')
+        # self.bio = self.artist.get_bio()
+        # print('bio')
+        self.similar = None
+        self.bio = None
 
     def _load_finish(self) -> None:
         self.set_title(self.artist.name)
@@ -104,7 +110,7 @@ class HTArtistPage(Page):
             _("Appears On"), self.albums_other, self.artist.get_albums_other
         )
 
-        self.new_carousel_for(_("Similar Artists"), self.similar)
+        # self.new_carousel_for(_("Similar Artists"), self.similar)
 
         if self.bio is None:
             return

--- a/src/window.py
+++ b/src/window.py
@@ -255,7 +255,7 @@ class HighTideWindow(Adw.ApplicationWindow):
             print(f"error! {e}")
             GLib.idle_add(self.on_login_failed)
         else:
-            utils.get_favourites(sort_favourite_tracks=True)
+            utils.get_favourites()
             GLib.idle_add(self.on_logged_in)
 
     def logout(self):
@@ -739,6 +739,11 @@ class HighTideWindow(Adw.ApplicationWindow):
         if self.settings.get_boolean("discord-rpc") != state:
             self.settings.set_boolean("discord-rpc", state)
             self.player_object.set_discord_rpc(state)
+    
+    def sort_favourites_by_added_toggled(self, state):
+        if self.settings.get_boolean("sort-favourites-by-added") != state:
+            self.settings.set_boolean("sort-favourites-by-added", state)
+            # show restarting the app is necessary
 
     #
     #   PAGES ACTIONS CALLBACKS

--- a/src/window.py
+++ b/src/window.py
@@ -255,7 +255,7 @@ class HighTideWindow(Adw.ApplicationWindow):
             print(f"error! {e}")
             GLib.idle_add(self.on_login_failed)
         else:
-            utils.get_favourites()
+            utils.get_favourites(sort_favourite_tracks=True)
             GLib.idle_add(self.on_logged_in)
 
     def logout(self):

--- a/src/window.py
+++ b/src/window.py
@@ -272,10 +272,16 @@ class HighTideWindow(Adw.ApplicationWindow):
     def on_logged_in(self):
         """Handle successful user login"""
         print("logged in")
-
+        show_my_collection_on_login = True
         page = HTGenericPage.new_from_function(utils.session.home).load()
+        # broken with tidalapi-0.8.5
         page.set_tag("home")
         self.navigation_view.replace([page])
+        if show_my_collection_on_login:
+            page = HTCollectionPage().load()
+            page.set_tag("collection")
+            self.navigation_view.push(page)
+        print("replacing home page, is broken I think")
 
         self.player_lyrics_queue.set_sensitive(True)
         self.navigation_buttons.set_sensitive(True)


### PR DESCRIPTION
tidalapi updated to 0.8.5:
- allows sorting by date added in the querry to the api
- but that breaks the homepage and artists page

setting to enable sorting by added in my collection


maybe add setting to select which page is selected on startup (home vs explore vs collection)