### PR TITLE
Round volume read from playbin to 1 decimal

### DIFF
--- a/src/lib/player_object.py
+++ b/src/lib/player_object.py
@@ -509,9 +509,9 @@ class PlayerObject(GObject.GObject):
         """
         volume = self.playbin.get_property("volume")
         if self.quadratic_volume:
-            return volume ** (1 / 2)
+            return round(volume ** (1 / 2), 1)
         else:
-            return volume
+            return round(volume, 1)
 
     def change_volume(self, value):
         """Set the playback volume.


### PR DESCRIPTION
Fixes #138 

Turns out the volume read from playbin is a wild decimal for basically any volume.
For example:

- 0.6000000000000001
- 0.8999999999999999
- 0.30000000000000004
- 0.36000204041308237
- 0.5999933844758054

And in the case of volume 1: 0.09999677905883801

With this change, they are rounded to .1, which results in correct volume for all steps (I tried)