### PR TITLE
Don't create multiline secret

### DIFF
--- a/src/lib/secret_storage.py
+++ b/src/lib/secret_storage.py
@@ -108,7 +108,7 @@ class SecretStore:
             "expiry-time": str(expiry_time),
         }
 
-        json_data: str = json.dumps(self.token_dictionary, indent=2)
+        json_data: str = json.dumps(self.token_dictionary)
 
         Secret.password_store_sync(
             self.schema, {}, Secret.COLLECTION_DEFAULT, self.key, json_data, None


### PR DESCRIPTION
When you have an unencrypted secret store (i.e. empty password), the secret is stored as passed, and the multiline breaks the keyring format.

```
gnome-keyring-daemon[188552]: keyring was in an invalid or unrecognized format: <home>/.local/share/keyrings/Default.keyring
```