### PR TITLE
Fix build failure caused by wrong charset in it.po

### DIFF
--- a/po/it.po
+++ b/po/it.po
@@ -14,7 +14,7 @@ msgstr ""
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
 #: data/gtk/help-overlay.blp:11


### PR DESCRIPTION
charset=CHARSET causes build failure. Fix by setting to UTF-8. Resolves #205.
```
INFO: autodetecting backend as ninja
INFO: calculating backend command to run: /usr/bin/ninja -C /home/user/projektit/high-tide/builddir
ninja: Entering directory `/home/user/projektit/high-tide/builddir'
[1/2] Building translation po/it/LC_MESSAGES/high-tide-it.mo
FAILED: [code=1] po/it/LC_MESSAGES/high-tide.mo 
/usr/bin/msgfmt -o po/it/LC_MESSAGES/high-tide.mo ../po/it.po
../po/it.po: warning: Charset "CHARSET" is not a portable encoding name.
                      Message conversion to user's charset might not work.
/usr/bin/msgfmt: present charset "CHARSET" is not a portable encoding name
[2/2] Generating data/high-tide_gresource with a custom command
ninja: build stopped: subcommand failed.
```
