### PR TITLE
Fix some MPRIS bugs, add support for shuffle/loop controls

### DIFF
--- a/src/lib/player_object.py
+++ b/src/lib/player_object.py
@@ -700,14 +700,8 @@ class PlayerObject(GObject.GObject):
         Returns:
             int: Duration in nanoseconds, or 0 if query failed
         """
-        logger.info("query_duration")
         success, duration = self.playbin.query_duration(Gst.Format.TIME)
-        if success:
-            logger.info(f"success, duration: {duration}")
-            self.emit("duration-changed")
-            return duration
-        else:
-            return 0
+        return duration if success else 0
 
     def query_position(self, default=0) -> int | None:
         """Get the current playback position.


### PR DESCRIPTION
Fixes some MPRIS interface bugs:

- Track ID was randomly generated at startup and never changed (?!), confusing several other apps that expected it to update. Fixed by using the tidal track ID.
- Fix duration always being 0 on the first track played due to a race condition
  - Seems that the metadata change event happens before GStreamer has fully buffered the track, so the duration is still zero.
  - Fix by just using the tidal metadata duration.

Additionally, add support for reading and writing the shuffle and loop status over the MPRIS interface.