### PR TITLE
feat: option to hide singles, EPs and albums by content restriction type

### DIFF
--- a/data/io.github.nokse22.high-tide.gschema.xml
+++ b/data/io.github.nokse22.high-tide.gschema.xml
@@ -29,6 +29,9 @@
 	    <range min="0" max="6"/>
       <default>0</default>
     </key>
+	  <key name="alsa-device" type="s">
+      <default>'default'</default>
+    </key>
 	  <key name="run-background" type="b">
       <default>false</default>
     </key>
@@ -47,8 +50,8 @@
 	  <key name="discord-rpc" type="b">
       <default>true</default>
     </key>
-	  <key name="alsa-device" type="s">
-      <default>'default'</default>
+    <key name="content-restriction" type="i">
+      <default>0</default>
     </key>
 	</schema>
 </schemalist>

--- a/data/style.css
+++ b/data/style.css
@@ -75,12 +75,12 @@
   background-color: transparent;
 }
 
-.lyrics-widget>row {
+.lyrics-widget > row {
   background-color: transparent;
   padding: 0px;
 }
 
-.lyrics-widget>row label {
+.lyrics-widget > row label {
   transition: background-color 0.1s ease-in-out;
   font-weight: bold;
   font-size: 14pt;
@@ -89,18 +89,18 @@
   padding: 6px;
 }
 
-.lyrics-widget>row label:hover {
+.lyrics-widget > row label:hover {
   background-color: alpha(var(--view-fg-color), 0.04);
 }
 
-.lyrics-widget>row:selected label {
+.lyrics-widget > row:selected label {
   background-color: alpha(var(--view-fg-color), 0.07);
   color: var(--accent-color);
   padding-top: 24px;
   padding-bottom: 24px;
 }
 
-.lyrics-widget>row:selected:hover {
+.lyrics-widget > row:selected:hover {
   color: alpha(var(--accent-color), 0.9);
 }
 
@@ -131,16 +131,19 @@
   padding-right: 6px;
 }
 
-.sidebar-progress-bar trough { /* codespell:ignore trough */
-  border-radius:0px;
+.sidebar-progress-bar trough {
+  /* codespell:ignore trough */
+  border-radius: 0px;
   background-color: transparent;
 }
 
-.sidebar-progress-bar trough > progress { /* codespell:ignore trough */
-  border-radius:0px;
-  background-color:alpha(var(--window-fg-color), 0.05);
+.sidebar-progress-bar trough > progress {
+  /* codespell:ignore trough */
+  border-radius: 0px;
+  background-color: alpha(var(--window-fg-color), 0.05);
 }
 
 dropdown button:not(:hover) {
   background-color: transparent;
 }
+

--- a/data/ui/preferences.blp
+++ b/data/ui/preferences.blp
@@ -30,30 +30,42 @@ Adw.PreferencesDialog _preference_window {
         };
 
         title: _("Preferred Audio Sink");
-        subtitle: _("Gapless playback is disabled for the native Pipewire Sink due to a bug. Use 'Automatic' for gapless playback.");
+        subtitle: _("Gapless playback is disabled for Pipewire, so use 'Automatic' for now");
       }
       Adw.ComboRow _alsa_device_row{
         title: _("ALSA Device");
         subtitle: _("Device used for exclusive ALSA access");
       }
       Adw.SwitchRow _normalize_row {
-        title: _("Normalize volume");
+        title: _("Normalize Volume");
       }
     }
 
     Adw.PreferencesGroup {
       title: _("App");
       Adw.SwitchRow _background_row {
-        title: _("Run in the background");
+        title: _("Run In Background");
       }
       Adw.SwitchRow _quadratic_volume_row {
-        title: _("Use quadratic volume control");
+        title: _("Quadratic Volume Control");
       }
       Adw.SwitchRow _video_cover_row {
-        title: _("Display animated covers");
+        title: _("Display Animated Covers");
       }
       Adw.SwitchRow _discord_rpc_row {
         title: _("Enable Discord Rich Presence");
+      }
+      Adw.ComboRow _content_restriction_row {
+        title: _("Content Restriction");
+        subtitle: _("Control which content is shown based on explicit content labels");
+
+        model: StringList {
+          strings [
+            _("Show All"),
+            _("Hide Explicit"),
+            _("Explicit Only"),
+          ]
+        };
       }
     }
   }

--- a/src/main.py
+++ b/src/main.py
@@ -20,6 +20,7 @@
 import sys
 from gettext import gettext as _
 from typing import Any, Callable, List
+from datetime import datetime
 
 from gi.repository import Adw, Gio, Gtk
 
@@ -97,9 +98,10 @@ class HighTideApplication(Adw.Application):
                 "Nila The Dragon https://github.com/nilathedragon",
                 "Dråfølin https://github.com/drafolin",
                 "Plamper https://github.com/Plamper",
+                "p0ryae https://github.com/p0ryae",
             ],
-            copyright="© 2023-2025 Nokse",
-            license_type="GTK_LICENSE_GPL_3_0",
+            copyright=f"© 2023-{datetime.now().year} Nokse",
+            license_type=Gtk.License.GPL_3_0,
             issue_url="https://github.com/Nokse22/high-tide/issues",
             website="https://github.com/Nokse22/high-tide",
         )
@@ -165,6 +167,13 @@ class HighTideApplication(Adw.Application):
             )
             builder.get_object("_discord_rpc_row").connect(
                 "notify::active", self.on_discord_rpc_changed
+            )
+
+            builder.get_object("_content_restriction_row").set_selected(
+                self.settings.get_int("content-restriction")
+            )
+            builder.get_object("_content_restriction_row").connect(
+                "notify::selected", self.on_content_restriction_changed
             )
 
             self.alsa_row = builder.get_object("_alsa_device_row")
@@ -240,6 +249,11 @@ class HighTideApplication(Adw.Application):
 
     def on_discord_rpc_changed(self, widget: Any, *args) -> None:
         self.win.change_discord_rpc_enabled(widget.get_active())
+
+    def on_content_restriction_changed(self, widget: Any, *args) -> None:
+        value = widget.get_selected()
+        self.settings.set_int("content-restriction", value)
+        self.win.change_content_restriction(value)
 
     def deactive_alsa_device_row(self, widget: Any, *args) -> None:
         alsa_used = widget.get_selected() == AudioSink.ALSA

--- a/src/pages/artist_page.py
+++ b/src/pages/artist_page.py
@@ -21,6 +21,7 @@ import logging
 import threading
 from gettext import gettext as _
 from typing import List
+from functools import partial
 
 from gi.repository import GLib, Gtk
 
@@ -61,19 +62,21 @@ class HTArtistPage(Page):
             self.top_tracks = []
 
         try:
-            self.albums = self.artist.get_albums(limit=10)
+            self.albums = utils.get_albums(self.artist, post_limit=10)
         except Exception as e:
             logger.warning(f"Failed to load albums for {self.artist}: {e}")
             self.albums = []
 
         try:
-            self.albums_ep_singles = self.artist.get_albums_ep_singles(limit=10)
+            self.albums_ep_singles = utils.get_albums_ep_singles(
+                self.artist, post_limit=10
+            )
         except Exception as e:
             logger.warning(f"Failed to load EPs/singles for {self.artist}: {e}")
             self.albums_ep_singles = []
 
         try:
-            self.albums_other = self.artist.get_albums_other(limit=10)
+            self.albums_other = utils.get_albums_other(self.artist, post_limit=10)
         except Exception as e:
             logger.warning(f"Failed to load other albums for {self.artist}: {e}")
             self.albums_other = []
@@ -152,14 +155,31 @@ class HTArtistPage(Page):
             _("Top Tracks"), self.top_tracks, self.artist.get_top_tracks
         )
 
-        self.new_carousel_for(_("Albums"), self.albums, self.artist.get_albums)
-
         self.new_carousel_for(
-            _("EP & Singles"), self.albums_ep_singles, self.artist.get_albums_ep_singles
+            _("Albums"),
+            self.albums,
+            partial(
+                utils.get_albums,
+                self.artist,
+            ),
         )
 
         self.new_carousel_for(
-            _("Appears On"), self.albums_other, self.artist.get_albums_other
+            _("EP & Singles"),
+            self.albums_ep_singles,
+            partial(
+                utils.get_albums_ep_singles,
+                self.artist,
+            ),
+        )
+
+        self.new_carousel_for(
+            _("Appears On"),
+            self.albums_other,
+            partial(
+                utils.get_albums_other,
+                self.artist,
+            ),
         )
 
         self.new_carousel_for(_("Similar Artists"), self.similar)

--- a/src/widgets/carousel_widget.py
+++ b/src/widgets/carousel_widget.py
@@ -50,20 +50,26 @@ class HTCarouselWidget(Gtk.Box, IDisconnectable):
         IDisconnectable.__init__(self)
         super().__init__()
 
-        self.signals.append((
-            self.next_button,
-            self.next_button.connect("clicked", self.carousel_go_next),
-        ))
+        self.signals.append(
+            (
+                self.next_button,
+                self.next_button.connect("clicked", self.carousel_go_next),
+            )
+        )
 
-        self.signals.append((
-            self.prev_button,
-            self.prev_button.connect("clicked", self.carousel_go_prev),
-        ))
+        self.signals.append(
+            (
+                self.prev_button,
+                self.prev_button.connect("clicked", self.carousel_go_prev),
+            )
+        )
 
-        self.signals.append((
-            self.more_button,
-            self.more_button.connect("clicked", self.on_more_clicked),
-        ))
+        self.signals.append(
+            (
+                self.more_button,
+                self.more_button.connect("clicked", self.on_more_clicked),
+            )
+        )
 
         self.n_pages = 0
 

--- a/src/window.py
+++ b/src/window.py
@@ -685,7 +685,7 @@ class HighTideWindow(Adw.ApplicationWindow):
 
         self.settings.set_int("quality", pos)
 
-    def change_audio_sink(self, sink):
+    def change_audio_sink(self, sink: int):
         if self.settings.get_int("preferred-sink") != sink:
             self.player_object.change_audio_sink(sink)
             self.settings.set_int("preferred-sink", sink)
@@ -740,10 +740,14 @@ class HighTideWindow(Adw.ApplicationWindow):
                     args=(self.playing_track_picture, album, self.image_canc),
                 ).start()
 
-    def change_discord_rpc_enabled(self, state):
+    def change_discord_rpc_enabled(self, state: bool):
         if self.settings.get_boolean("discord-rpc") != state:
             self.settings.set_boolean("discord-rpc", state)
             self.player_object.set_discord_rpc(state)
+
+    def change_content_restriction(self, value: int):
+        if self.settings.get_int("content-restriction") != value:
+            self.settings.set_int("content-restriction", value)
 
     #
     #   PAGES ACTIONS CALLBACKS


### PR DESCRIPTION
implements #248

**Notes:**

1. Default is show all
2. Picking any other option is treated as a preference. If a user selects Explicit Only we won't hide clean versions if there is no explicit version that exists for that album / single etc..
3. Same thing for Hide Explicit. We return explicit albums if there are no clean versions.  