### PR TITLE
fix: retry TIDAL session connection on ConnectionResetError

### DIFF
--- a/src/lib/utils.py
+++ b/src/lib/utils.py
@@ -29,8 +29,11 @@ from pathlib import Path
 from typing import Any, List
 
 import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 from gi.repository import Adw, Gdk, Gio, GLib
 
+import tidalapi
 from tidalapi.album import Album
 from tidalapi.artist import Artist
 from tidalapi.mix import Mix
@@ -789,6 +792,14 @@ def replace_links(text: str) -> str:
     replaced_text = re.sub(pattern, replace, escaped_text)
 
     return replaced_text
+
+
+def create_tidal_session():
+    tidal_session = tidalapi.Session()
+    retry = Retry(connect=3, backoff_factor=0.5)
+    adapter = HTTPAdapter(max_retries=retry)
+    tidal_session.request_session.mount("https://", adapter)
+    return tidal_session
 
 
 def setup_logging():

--- a/src/window.py
+++ b/src/window.py
@@ -177,7 +177,7 @@ class HighTideWindow(Adw.ApplicationWindow):
         self.artist_label.connect("activate-link", utils.open_uri)
         self.miniplayer_artist_label.connect("activate-link", utils.open_uri)
 
-        self.session = tidalapi.Session()
+        self.session = utils.create_tidal_session()
 
         utils.session = self.session
         utils.navigation_view = self.navigation_view


### PR DESCRIPTION
## Problem                                                                                                        

  During playlist/album playback, TIDAL's server occasionally resets the HTTP  connection after a period of inactivity (between tracks). This causes `urllib3` to raise a `ConnectionResetError` when fetching the next track's stream URL, interrupting playback and requiring the user to manually advance to the next track.                               
                                                                                                                    
  The error occurs in `_play_track_thread` when calling `track.get_stream()`:
  requests.exceptions.ConnectionError: ('Connection aborted.', ConnectionResetError(104, 'Connection reset by peer'))

`
2026-03-04 19:08:54,061 [ERROR] high_tide.lib.player_object: Error getting track URL
Traceback (most recent call last):
  File "/usr/lib/python3.14/site-packages/urllib3/connectionpool.py", line 787, in urlopen
    response = self._make_request(
        conn,
    ...<10 lines>...
        **response_kw,
    )
  File "/usr/lib/python3.14/site-packages/urllib3/connectionpool.py", line 534, in _make_request
    response = conn.getresponse()
  File "/usr/lib/python3.14/site-packages/urllib3/connection.py", line 571, in getresponse
    httplib_response = super().getresponse()
  File "/usr/lib/python3.14/http/client.py", line 1450, in getresponse
    response.begin()
    ~~~~~~~~~~~~~~^^
  File "/usr/lib/python3.14/http/client.py", line 336, in begin
    version, status, reason = self._read_status()
                              ~~~~~~~~~~~~~~~~~^^
  File "/usr/lib/python3.14/http/client.py", line 297, in _read_status
    line = str(self.fp.readline(_MAXLINE + 1), "iso-8859-1")
               ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^
  File "/usr/lib/python3.14/socket.py", line 725, in readinto
    return self._sock.recv_into(b)
           ~~~~~~~~~~~~~~~~~~~~^^^
  File "/usr/lib/python3.14/ssl.py", line 1304, in recv_into
    return self.read(nbytes, buffer)
           ~~~~~~~~~^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.14/ssl.py", line 1138, in read
    return self._sslobj.read(len, buffer)
           ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
ConnectionResetError: [Errno 104] Connection reset by peer

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3.14/site-packages/requests/adapters.py", line 644, in send
    resp = conn.urlopen(
        method=request.method,
    ...<9 lines>...
        chunked=chunked,
    )
  File "/usr/lib/python3.14/site-packages/urllib3/connectionpool.py", line 841, in urlopen
    retries = retries.increment(
        method, url, error=new_e, _pool=self, _stacktrace=sys.exc_info()[2]
    )
  File "/usr/lib/python3.14/site-packages/urllib3/util/retry.py", line 490, in increment
    raise reraise(type(error), error, _stacktrace)
          ~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.14/site-packages/urllib3/util/util.py", line 38, in reraise
    raise value.with_traceback(tb)
  File "/usr/lib/python3.14/site-packages/urllib3/connectionpool.py", line 787, in urlopen
    response = self._make_request(
        conn,
    ...<10 lines>...
        **response_kw,
    )
  File "/usr/lib/python3.14/site-packages/urllib3/connectionpool.py", line 534, in _make_request
    response = conn.getresponse()
  File "/usr/lib/python3.14/site-packages/urllib3/connection.py", line 571, in getresponse
    httplib_response = super().getresponse()
  File "/usr/lib/python3.14/http/client.py", line 1450, in getresponse
    response.begin()
    ~~~~~~~~~~~~~~^^
  File "/usr/lib/python3.14/http/client.py", line 336, in begin
    version, status, reason = self._read_status()
                              ~~~~~~~~~~~~~~~~~^^
  File "/usr/lib/python3.14/http/client.py", line 297, in _read_status
    line = str(self.fp.readline(_MAXLINE + 1), "iso-8859-1")
               ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^
  File "/usr/lib/python3.14/socket.py", line 725, in readinto
    return self._sock.recv_into(b)
           ~~~~~~~~~~~~~~~~~~~~^^^
  File "/usr/lib/python3.14/ssl.py", line 1304, in recv_into
    return self.read(nbytes, buffer)
           ~~~~~~~~~^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.14/ssl.py", line 1138, in read
    return self._sslobj.read(len, buffer)
           ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
urllib3.exceptions.ProtocolError: ('Connection aborted.', ConnectionResetError(104, 'Connection reset by peer'))

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/home/hernanh/.local/share/high-tide/high_tide/lib/player_object.py", line 477, in _play_track_thread
    self.stream = track.get_stream()
                  ~~~~~~~~~~~~~~~~^^
  File "/usr/lib/python3.14/site-packages/tidalapi/media.py", line 515, in get_stream
    request = self.requests.request(
        "GET", "tracks/%s/playbackinfopostpaywall" % self.id, params
    )
  File "/usr/lib/python3.14/site-packages/tidalapi/request.py", line 150, in request
    request = self.basic_request(method, path, params, data, headers, base_url)
  File "/usr/lib/python3.14/site-packages/tidalapi/request.py", line 103, in basic_request
    request = self.session.request_session.request(
        method, url, params=request_params, data=data, headers=headers
    )
  File "/usr/lib/python3.14/site-packages/requests/sessions.py", line 589, in request
    resp = self.send(prep, **send_kwargs)
  File "/usr/lib/python3.14/site-packages/requests/sessions.py", line 703, in send
    r = adapter.send(request, **kwargs)
  File "/usr/lib/python3.14/site-packages/requests/adapters.py", line 659, in send
    raise ConnectionError(err, request=request)
requests.exceptions.ConnectionError: ('Connection aborted.', ConnectionResetError(104, 'Connection reset by peer'))
`

  ## Fix                                                                                                            
                                                                                                                    
  - Encapsulates TIDAL session creation in `utils.create_tidal_session()`
  - Mounts an `HTTPAdapter` with `Retry(connect=3, backoff_factor=0.5)` on the session, so `urllib3` automatically retries the connection before raising an exception

  ## Test plan

  - [ ] Play a playlist or album with several tracks
  - [ ] Verify playback continues uninterrupted between tracks
  - [ ] With `LOG_LEVEL=DEBUG`, confirm `urllib3` retries the connection automatically when a reset occurs