### PR TITLE
Remove limit of 10 visible playlists in add-to-playlist

### DIFF
--- a/src/widgets/generic_track_widget.py
+++ b/src/widgets/generic_track_widget.py
@@ -150,8 +150,6 @@ class HTGenericTrackWidget(Gtk.ListBoxRow, IDisconnectable):
         self.action_group.add_action(add_to_playlist_action)
 
         for index, playlist in enumerate(utils.user_playlists):
-            if index > 10:
-                break
             item = Gio.MenuItem.new()
             item.set_label(playlist.name)
             item.set_action_and_target_value(


### PR DESCRIPTION
The number of visible playlists was restricted to 10. This limit has been removed so no limit exists.