### PR TITLE
Fix Discord RPC crash and clear status on pause

### DIFF
--- a/src/lib/discord_rpc.py
+++ b/src/lib/discord_rpc.py
@@ -100,10 +100,9 @@ def set_activity(track: Track | None = None, offset_ms: int = 0) -> None:
         try:
             if state != State.DISCONNECTED:
                 rpc.clear()
-                rpc.close()
         except Exception:
             pass
-        state = State.DISCONNECTED
+        state = State.IDLE
         return
 
     if state == State.DISCONNECTED:
@@ -123,12 +122,19 @@ def set_activity(track: Track | None = None, offset_ms: int = 0) -> None:
             rpc.update(
                 activity_type=ActivityType.LISTENING,
                 details=track.name,
-                name=", ".join(artists) if artists else "Unknown Artist",
-                state=", ".join(artists) if artists else "Unknown Artist",
-                large_image=track.album.image() if track.album else "hightide_x1024",
-                small_text="High Tide" if track.album else None,
+                state=", ".join(artists)
+                if artists
+                else "Unknown Artist",
+                large_image=track.album.image()
+                if track.album
+                else "hightide_x1024",
+                small_text="High Tide"
+                if track.album
+                else None,
                 start=int(time.time() - offset_ms),
-                end=int(time.time() - offset_ms + track.duration),
+                end=int(
+                    time.time() - offset_ms + track.duration
+                ),
             )
             state = State.PLAYING
     except pypresence.exceptions.PipeClosed:

--- a/src/lib/player_object.py
+++ b/src/lib/player_object.py
@@ -750,7 +750,8 @@ class PlayerObject(GObject.GObject):
         self.discord_rpc_enabled = enabled
         if enabled and self.playing:
             discord_rpc.set_activity(
-                self.playing_track, int(self.query_duration()) // 1_000_000_000
+                self.playing_track,
+                self.query_position() / 1_000_000_000,
             )
         elif enabled:
             discord_rpc.set_activity()


### PR DESCRIPTION
This fixes two related Discord RPC issues.

The `name` kwarg passed to `rpc.update()` was overriding the app name with the artist string, which isn't what we want. Artist info is already in `state`. Removed it.

When pausing, `set_activity()` was calling `rpc.close()` which fully disconnects from Discord IPC. This means Discord would briefly show stale "listening" status until the close propagated, and resuming needed a full reconnect. Now it just calls `rpc.clear()` and keeps the connection alive, so the status drops right away and resume is instant.

Also noticed `set_discord_rpc()` in player_object.py was passing `query_duration()` (total track length) instead of `query_position()` (where we actually are) when re-enabling RPC, so the timestamp was wrong. Fixed that too.

Fixes #256, fixes #260