### PR TITLE
fix: show correct track count and duration for large playlists/albums…

### DIFF
--- a/src/pages/track_list_page.py
+++ b/src/pages/track_list_page.py
@@ -45,10 +45,15 @@ class TrackListPage(Page):
 
         builder.get_object("_title_label").set_label(title)
         builder.get_object("_first_subtitle_label").set_label(subtitle)
+        item = getattr(self, "item", None)
+        num_tracks = getattr(item, "num_tracks", None) or len(tracks)
+        total_duration = getattr(item, "duration", None) or sum(
+            (t.duration or 0) for t in tracks
+        )
         builder.get_object("_second_subtitle_label").set_label(
             _("{} tracks ({})").format(
-                len(tracks),
-                utils.pretty_duration(sum((t.duration or 0) for t in tracks)),
+                num_tracks,
+                utils.pretty_duration(total_duration),
             )
         )
 


### PR DESCRIPTION
Shows correct number of tracks in playlist subtitle.  The number of tracks was computed from the initially-fetched page of tracks (limit=50), so playlists and albums with more than 50 tracks always displayed "50 tracks" with an incorrect total duration. Use num_tracks and duration from the tidalapi object instead, which carry the real totals from the API. Falls back to len(tracks) for pages that don't expose those attributes.