### PR TITLE
Adding SOCKS support back after it was removed.

### DIFF
--- a/build-aux/python3-tidalapi.json
+++ b/build-aux/python3-tidalapi.json
@@ -2,7 +2,7 @@
     "name": "python3-tidalapi",
     "buildsystem": "simple",
     "build-commands": [
-        "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"tidalapi\" --no-build-isolation"
+        "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"tidalapi\" \"requests[socks]\" --no-build-isolation"
     ],
     "sources": [
         {
@@ -59,6 +59,11 @@
             "type": "file",
             "url": "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl",
             "sha256": "f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/8d/59/b4572118e098ac8e46e399a1dd0f2d85403ce8bbaad9ec79373ed6badaf9/PySocks-1.7.1-py3-none-any.whl",
+            "sha256": "2725bd0a9925919b9b51739eea5f9e2bae91e83288108a9ad338b2e3a4435ee5"
         },
         {
             "type": "file",


### PR DESCRIPTION
The dependency was removed in eae1c979ee5a098e109fe4a0d4480f3e4962b35b, probably by mistake, but I'm not sure. This PR adds back what has already once been added back in #124.

Thanks!