### PR TITLE
Enable wrap in app id dialog

### DIFF
--- a/data/ui/window.blp
+++ b/data/ui/window.blp
@@ -12,6 +12,7 @@ Adw.AlertDialog app_id_dialog {
     spacing: 12;
     Label {
       label: "flatpak uninstall io.github.nokse22.HighTide --delete-data";
+      wrap: true;
       selectable: true;
     }
     CheckButton check_btn {


### PR DESCRIPTION
App Id Dialog label is too long and therefore dialog is too wide on mobile. Set it to wrap so it can fit on screen.