### PR TITLE
Fix gettext warning about single-quoted strings

### DIFF
--- a/data/ui/widgets/carousel_widget.blp
+++ b/data/ui/widgets/carousel_widget.blp
@@ -24,7 +24,7 @@ template $HTCarouselWidget: Box {
     }
 
     Button more_button {
-      label: _('More');
+      label: _("More");
 
       styles [
         "small-pill",

--- a/data/ui/widgets/tracks_list_widget.blp
+++ b/data/ui/widgets/tracks_list_widget.blp
@@ -21,7 +21,7 @@ template $HTTracksListWidget: Box {
     }
 
     Button more_button {
-      label: _('More');
+      label: _("More");
 
       styles [
         "small-pill",


### PR DESCRIPTION
Fix: warning: gettext may not recognize single-quoted strings