### PR TITLE
Fix #277: switch login to PKCE flow for FLAC/HiRes streams

### DIFF
--- a/data/ui/login.blp
+++ b/data/ui/login.blp
@@ -3,8 +3,8 @@ using Adw 1;
 
 template $LoginDialog: Adw.Dialog {
   title: _("Log In");
-  content-height: 220;
-  content-width: 360;
+  content-height: 320;
+  content-width: 420;
 
   Adw.ToolbarView {
     [top]
@@ -17,41 +17,57 @@ template $LoginDialog: Adw.Dialog {
       margin-top: 12;
       orientation: vertical;
       spacing: 12;
-      vexpand: true;
 
       Label {
-        label: _("Go to this website and login with your account, if it asks for a code insert the code provided below.");
-        vexpand: true;
+        label: _("Sign in on Tidal, then paste the URL you get redirected to.");
         wrap: true;
+        xalign: 0;
       }
 
       LinkButton link_button {
         halign: center;
-        label: 'www.tidal.login/IEOUE';
-        uri: 'prova.com';
+        label: _("Open Tidal Login");
       }
 
-      Box {
+      ListBox {
+        selection-mode: none;
+
+        styles [
+          "boxed-list",
+        ]
+
+        Adw.EntryRow redirect_url_entry {
+          title: _("Redirect URL");
+          activates-default: true;
+          changed => $on_redirect_url_changed();
+          entry-activated => $on_login_button_clicked();
+        }
+      }
+
+      Label error_label {
+        visible: false;
+        wrap: true;
+        xalign: 0;
+
+        styles [
+          "error",
+        ]
+      }
+
+      Button login_button {
+        sensitive: false;
+        label: _("Log In");
         halign: center;
-        spacing: 12;
-        valign: start;
+        valign: end;
         vexpand: true;
+        margin-top: 6;
 
-        Label code_label {
-          label: 'WEOID';
-        }
+        styles [
+          "suggested-action",
+          "pill",
+        ]
 
-        Button {
-          halign: center;
-          icon-name: 'edit-copy-symbolic';
-          valign: center;
-
-          styles [
-            "circular",
-          ]
-
-          clicked => $on_copy_code_button_clicked();
-        }
+        clicked => $on_login_button_clicked();
       }
     };
   }

--- a/src/lib/secret_storage.py
+++ b/src/lib/secret_storage.py
@@ -93,7 +93,7 @@ class SecretStore:
 
         Secret.password_clear_sync(self.schema, {}, None)
 
-    def save(self) -> None:
+    def save(self, is_pkce: bool = False) -> None:
         """Save the current session tokens to secure storage.
 
         Stores the session's token_type, access_token, and refresh_token
@@ -109,6 +109,7 @@ class SecretStore:
             "access-token": access_token,
             "refresh-token": refresh_token,
             "expiry-time": str(expiry_time),
+            "is-pkce": is_pkce,
         }
 
         json_data: str = json.dumps(self.token_dictionary)

--- a/src/login.py
+++ b/src/login.py
@@ -17,10 +17,15 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+import logging
+import threading
+from gettext import gettext as _
 from typing import Any
 
 import tidalapi
-from gi.repository import Adw, Gdk, GLib, Gtk
+from gi.repository import Adw, GLib, Gtk
+
+logger = logging.getLogger(__name__)
 
 
 @Gtk.Template(resource_path="/io/github/nokse22/high-tide/ui/login.ui")
@@ -28,7 +33,9 @@ class LoginDialog(Adw.Dialog):
     __gtype_name__ = "LoginDialog"
 
     link_button = Gtk.Template.Child()
-    code_label = Gtk.Template.Child()
+    redirect_url_entry = Gtk.Template.Child()
+    login_button = Gtk.Template.Child()
+    error_label = Gtk.Template.Child()
 
     def __init__(self, win: Any, session: tidalapi.Session) -> None:
         super().__init__()
@@ -36,36 +43,49 @@ class LoginDialog(Adw.Dialog):
         self.session = session
         self.win = win
 
-        self.code: str = ""
+        login_url: str = self.session.pkce_login_url()
+        self.link_button.set_uri(login_url)
 
-        login, future = self.session.login_oauth()
+    @Gtk.Template.Callback("on_redirect_url_changed")
+    def on_redirect_url_changed(self, entry: Adw.EntryRow) -> None:
+        self.login_button.set_sensitive(bool(entry.get_text().strip()))
+        self.error_label.set_visible(False)
 
-        uri: str = login.verification_uri_complete
+    @Gtk.Template.Callback("on_login_button_clicked")
+    def on_login_button_clicked(self, *_args) -> None:
+        redirect_url: str = self.redirect_url_entry.get_text().strip()
+        if not redirect_url:
+            return
 
-        link: str = f"https://{uri}"
+        self.login_button.set_sensitive(False)
+        self.redirect_url_entry.set_sensitive(False)
+        self.error_label.set_visible(False)
 
-        self.code = uri[-5:]
+        threading.Thread(
+            target=self._exchange_token, args=(redirect_url,), daemon=True
+        ).start()
 
-        self.code_label.set_label(self.code)
-        self.link_button.set_label(link)
-        self.link_button.set_uri(link)
+    def _exchange_token(self, redirect_url: str) -> None:
+        try:
+            token_json = self.session.pkce_get_auth_token(redirect_url)
+            self.session.process_auth_token(token_json, is_pkce_token=True)
+        except Exception as exc:
+            logger.exception("PKCE token exchange failed")
+            GLib.idle_add(self._on_failure, str(exc))
+            return
 
-        GLib.timeout_add(600, self.check_login)
-
-    def check_login(self) -> bool:
-        """Check if we are logged in
-
-        Returns:
-            bool: whether we are logged in or not
-        """
         if self.session.check_login():
-            self.win.secret_store.save()
-            self.win.on_logged_in()
-            self.close()
-            return False
-        return True
+            GLib.idle_add(self._on_success)
+        else:
+            GLib.idle_add(self._on_failure, _("Login was rejected by Tidal."))
 
-    @Gtk.Template.Callback("on_copy_code_button_clicked")
-    def on_copy_code_button_clicked(self, btn: Gtk.Button) -> None:
-        clipboard: Gdk.Clipboard = Gdk.Display().get_default().get_clipboard()
-        clipboard.set(self.code)
+    def _on_success(self) -> None:
+        self.win.secret_store.save(is_pkce=True)
+        self.win.on_logged_in()
+        self.close()
+
+    def _on_failure(self, message: str) -> None:
+        self.error_label.set_label(_("Login failed: {error}").format(error=message))
+        self.error_label.set_visible(True)
+        self.redirect_url_entry.set_sensitive(True)
+        self.login_button.set_sensitive(True)

--- a/src/window.py
+++ b/src/window.py
@@ -244,12 +244,20 @@ class HighTideWindow(Adw.ApplicationWindow):
         login_dialog.present(self)
 
     def th_login(self):
+        if not self.secret_store.token_dictionary.get("is-pkce", False):
+            if self.secret_store.token_dictionary:
+                logger.info("Clearing legacy non-PKCE session, re-auth required")
+                self.secret_store.clear()
+            GLib.idle_add(self.on_login_failed)
+            return
+
         try:
             self.session.load_oauth_session(
                 self.secret_store.token_dictionary["token-type"],
                 self.secret_store.token_dictionary["access-token"],
                 self.secret_store.token_dictionary["refresh-token"],
                 self.secret_store.token_dictionary["expiry-time"],
+                is_pkce=True,
             )
         except Exception:
             logger.exception("Error while logging in!")


### PR DESCRIPTION
Closes #277.

Tidal changed their OAuth endpoint in late 2025. Tokens from `login_oauth()`
(the old PIN flow) only get AAC now, regardless of the quality setting.
FLAC and HiRes silently downgrade to AAC 320. The same break hit other
tidalapi-based apps: EbbLabs/python-tidal#404, oskvr37/tiddl#333,
nathom/streamrip#966.

PKCE-flow tokens still grant FLAC, so the login dialog moves to PKCE.

Changes:
- `data/ui/login.blp`: PIN code label and copy button replaced with an
  "Open Tidal Login" link, an EntryRow for the redirect URL, and a Log In
  button.
- `src/login.py`: uses `pkce_login_url()`, then exchanges the pasted
  redirect URL via `pkce_get_auth_token()` and
  `process_auth_token(..., is_pkce_token=True)`. Exchange runs on a
  background thread.
- `src/lib/secret_storage.py`: `save()` takes `is_pkce` and persists it.
- `src/window.py:th_login`: passes `is_pkce=True` to
  `load_oauth_session()`. Sessions saved before this PR don't have the
  flag (legacy device-flow tokens that won't get FLAC anyway), so they
  are cleared and the user re-auths once.

New user flow:
1. Tap Log In.
2. Click "Open Tidal Login". Tidal opens in a browser.
3. Sign in. Tidal redirects to a `tidal://` URL that the browser shows
   as a blank page. Expected.
4. Copy the full URL from the address bar, paste it into the dialog,
   click Log In.

Tested with tidalapi 0.8.11 on a HiFi Plus account. 24/96 FLAC tracks
now play at FLAC.