### PR TITLE
Fix duration label freezing at 00:00 during playback

### DIFF
--- a/src/window.py
+++ b/src/window.py
@@ -640,24 +640,21 @@ class HighTideWindow(Adw.ApplicationWindow):
         end_value = self.duration / Gst.SECOND
 
         self.volume_button.get_adjustment().set_value(self.player_object.query_volume())
-        position = self.player_object.query_position(default=None)
-        if position is None:
-            return
-        position = position / Gst.SECOND
-        fraction = 0
-
-        self.lyrics_widget.set_time(position)
-
         self.duration_label.set_label(utils.pretty_duration(end_value))
 
-        if end_value != 0:
-            fraction = position / end_value
+        position_ns = self.player_object.query_position(default=None)
+        if position_ns is None:
+            self.time_played_label.set_label(utils.pretty_duration(0))
+            return
+        position = position_ns / Gst.SECOND
+
+        self.lyrics_widget.set_time(position)
+        self.time_played_label.set_label(utils.pretty_duration(position))
+
+        fraction = position / end_value if end_value else 0
         self.small_progress_bar.set_fraction(fraction)
         self.progress_bar.get_adjustment().set_value(fraction)
-
         self.previous_fraction = fraction
-
-        self.time_played_label.set_label(utils.pretty_duration(position))
 
     def th_add_lyrics_to_page(self):
         try:


### PR DESCRIPTION
`update_slider` early-returned when `query_position` returned None, so
the duration label stayed at "00:00" until both queries succeeded.
Hoist the `duration_label` update so the total time renders as soon
as the player has a duration, fall back to "00:00" for elapsed time
when position isn't ready yet. Once position is queryable the elapsed
time and progress bar take over.

Note: I originally also had a Discord RPC crash fix here, but
ac8f6be already covers that case (and more comprehensively). Rebased
to drop the redundant change.

## Repro

Before: starting a track shows "00:00 / 00:00" until both
`query_position` and `query_duration` answer in TIME format. On DASH
streams (FLAC HiRes) that window can be a few hundred ms.

After: total time renders as soon as the player knows the duration;
elapsed time stays at "00:00" until position is queryable, then takes
over normally.