### PR TITLE
Fix dead key input on KDE Wayland

### DIFF
--- a/src/high-tide.in
+++ b/src/high-tide.in
@@ -31,6 +31,12 @@ localedir = '@localedir@'
 
 sys.path.insert(1, pkgdatadir)
 signal.signal(signal.SIGINT, signal.SIG_DFL)
+
+# On KDE Wayland the zwp_text_input_v3 protocol doesn't compose dead keys
+# correctly for GTK4 apps. Fall back to GTK's built-in simple IM context,
+# which uses xkbcommon compose tables and handles dead keys properly.
+# Only applied when the user hasn't explicitly chosen an IM module.
+os.environ.setdefault('GTK_IM_MODULE', 'simple')
 locale.bindtextdomain('high-tide', localedir)
 locale.textdomain('high-tide')
 gettext.bindtextdomain('high-tide', localedir)


### PR DESCRIPTION
GTK4's zwp_text_input_v3 integration doesn't compose dead keys correctly on KDE Plasma Wayland. Fall back to GTK's built-in simple IM context via GTK_IM_MODULE=simple, which uses xkbcommon compose tables and handles dead key sequences (e.g. ´ + a → á) properly. setdefault is used so users who have explicitly set GTK_IM_MODULE (e.g. for Fcitx5 or IBus) are unaffected.