### PR TITLE
Fix page title stuck on Loading and Mix auto-load error

### DIFF
--- a/src/pages/track_list_page.py
+++ b/src/pages/track_list_page.py
@@ -43,6 +43,7 @@ class TrackListPage(Page):
         if reload_function:
             self.auto_load.set_function(reload_function)
 
+        self.set_title(title)
         builder.get_object("_title_label").set_label(title)
         builder.get_object("_first_subtitle_label").set_label(subtitle)
         item = getattr(self, "item", None)

--- a/src/widgets/auto_load_widget.py
+++ b/src/widgets/auto_load_widget.py
@@ -127,12 +127,15 @@ class HTAutoLoadWidget(Gtk.Box, IDisconnectable):
             return
         self.is_loading = True
         self.spinner.set_visible(True)
-        new_items = []
-        new_items = self.function(limit=self.items_limit, offset=self.items_n)
+        try:
+            new_items = self.function(limit=self.items_limit, offset=self.items_n)
+        except TypeError:
+            new_items = []
         self.items.extend(new_items)
         if new_items == []:
             GObject.signal_handler_disconnect(self.scrolled_window, self.handler_id)
             self.spinner.set_visible(False)
+            self.is_loading = False
             return
         elif self.type is None:
             self.type = utils.get_type(new_items[0])


### PR DESCRIPTION
## Summary

  - `TrackListPage._setup_ui` now calls `self.set_title(title)` so the
    `Adw.NavigationPage` title (shown in the header/breadcrumb) updates
    from "Loading..." to the actual album/playlist/mix name once content
    is loaded.
  - `HTAutoLoadWidget.th_load_items` wraps the paginated fetch in a
    `try/except TypeError` so `Mix.items()`, which accepts no `limit`/
    `offset` kwargs, no longer logs an exception when the user scrolls to
    the bottom — it returns `[]` instead, which triggers the existing
    "no more items" path and disconnects the scroll handler.
  - Fixed a pre-existing bug where `is_loading` was never reset to `False`
    on the early-return (no more items) path in `th_load_items`.

  ## Test plan

  - [ ] Open an album page — header title shows the album name after loading
  - [ ] Open a playlist page — header title shows the playlist name
  - [ ] Open a mix page — header title shows the mix title
  - [ ] Scroll to the bottom of a mix — no `TypeError` in the logs

  Fixes #272
