### PR TITLE
login: clarify that the "Page not found" redirect is expected

### DIFF
--- a/data/ui/login.blp
+++ b/data/ui/login.blp
@@ -19,7 +19,7 @@ template $LoginDialog: Adw.Dialog {
       spacing: 12;
 
       Label {
-        label: _("Sign in on Tidal, then paste the URL you get redirected to.");
+        label: _("Sign in on Tidal. Your browser will redirect to a \"Page not found\" — that's expected. Copy the full URL from the address bar and paste it below.");
         wrap: true;
         xalign: 0;
       }
@@ -37,7 +37,7 @@ template $LoginDialog: Adw.Dialog {
         ]
 
         Adw.EntryRow redirect_url_entry {
-          title: _("Redirect URL");
+          title: _("Paste redirected URL here");
           activates-default: true;
           changed => $on_redirect_url_changed();
           entry-activated => $on_login_button_clicked();


### PR DESCRIPTION
Silly me, I failed to follow the instruction in the login dialog. When Tidal redirected me to `https://tidal.com/android/login/auth?code=..` and my browser rendered a big "Page not found", I assumed the OAuth flow was broken rather than realizing that broken-looking URL *is* the thing I'm supposed to copy back into the app.

Embarrassing, but maybe I'm not the only one who'll trip over it, so here's a tiny wording tweak that would have saved me. Feel free to close if you think it's noise. at this point, many thanks for your work :pray: 

todo
- [ ] Build and open the login dialog; verify the new label wraps cleanly at the dialog's 420px width.
- [ ] Confirm the entry row title is readable and doesn't truncate.