### PR TITLE
fix: deduplicate artist top tracks (#295)

### DIFF
--- a/src/widgets/tracks_list_widget.py
+++ b/src/widgets/tracks_list_widget.py
@@ -70,15 +70,18 @@ class HTTracksListWidget(Gtk.Box, IDisconnectable):
         self.tracks: List[Track] = []
 
     def set_more_function(self, function: Callable) -> None:
-        """Set the function to fetch more items
+        """Register the callback used to load the full list via the "More" button.
+
+        The visible tracks are provided separately through set_tracks_list(); this
+        method only stores the callback and reveals the "More" button, which opens
+        a dedicated page with the complete, correctly ordered list. It does not
+        fetch or render any tracks itself, so calling it after set_tracks_list()
+        does not duplicate the initial entries.
 
         Args:
-            function: the function"""
+            function: a callable returning the full list of tracks"""
         self.get_function = function
-        self.tracks = self.get_function(10)
         self.more_button.set_visible(True)
-
-        self._add_tracks()
 
     def set_tracks_list(self, tracks_list: List[Track]) -> None:
         self.tracks = tracks_list


### PR DESCRIPTION
On the artist page the Top Tracks list showed its first entries twice (1,2,3,4,5,1,2,3,4,5,6,...).

The cause is in `HTTracksListWidget.set_more_function()`. The artist page calls both `set_tracks_list()` (which already renders the prefetched top 5) and `set_more_function()`, and the latter additionally ran `self.tracks = self.get_function(10)` followed by `self._add_tracks()`, so the first batch was drawn a second time.

This makes `set_more_function()` only store the callback and reveal the More button, the same way `HTCarouselWidget.set_more_function()` already works. The list is now rendered once, the More button still opens the full ordered list, and clicking a row plays the correct track.

Closes #295
