### PR TITLE
Fix: ui fixes and styling cleanup

### DIFF
--- a/data/style.css
+++ b/data/style.css
@@ -14,6 +14,10 @@
   border-radius: 4px;
 }
 
+.player-view-switcher button image {
+  margin-right: 8px;
+}
+
 .now-playing {
   background-color: alpha(@accent_bg_color, 0.1);
 }
@@ -24,13 +28,13 @@
 }
 
 .card-bg {
-  transition: opacity 0.1s ease-in-out;
   transition: background-color 0.1s ease-in-out;
   border-radius: 14px;
+  background-color: @card_bg_color;
 }
 
 .card-bg:hover {
-  background-color: alpha(var(--window-fg-color), 0.1);
+  background-color: mix(@card_bg_color, @window_fg_color, 0.07);
 }
 
 .artist-link {
@@ -93,24 +97,24 @@
   transition: background-color 0.1s ease-in-out;
   font-weight: bold;
   font-size: 14pt;
-  color: alpha(var(--view-fg-color), 0.5);
+  color: alpha(@view_fg_color, 0.5);
   border-radius: 12px;
   padding: 6px;
 }
 
 .lyrics-widget>row label:hover {
-  background-color: alpha(var(--view-fg-color), 0.04);
+  background-color: alpha(@view_fg_color, 0.04);
 }
 
 .lyrics-widget>row:selected label {
-  background-color: alpha(var(--view-fg-color), 0.07);
-  color: var(--accent-color);
+  background-color: alpha(@view_fg_color, 0.07);
+  color: @accent_color;
   padding-top: 24px;
   padding-bottom: 24px;
 }
 
 .lyrics-widget>row:selected:hover {
-  color: alpha(var(--accent-color), 0.9);
+  color: alpha(@accent_color, 0.9);
 }
 
 .tracks-list-box {
@@ -125,15 +129,15 @@
 }
 
 .tracks-list-box row:nth-child(odd) {
-  background-color: alpha(var(--window-fg-color), 0.05);
+  background-color: alpha(@window_fg_color, 0.05);
 }
 
 .tracks-list-box row:hover {
-  background-color: alpha(var(--window-fg-color), 0.1);
+  background-color: alpha(@window_fg_color, 0.1);
 }
 
 .quality-label {
-  background-color: var(--popover-shade-color);
+  background-color: @popover_shade_color;
   border-radius: 4px;
   padding: 3px;
   padding-left: 6px;
@@ -147,7 +151,7 @@
 
 .sidebar-progress-bar trough > progress { /* codespell:ignore trough */
   border-radius:0px;
-  background-color:alpha(var(--window-fg-color), 0.05);
+  background-color:alpha(@window_fg_color, 0.05);
 }
 
 dropdown button:not(:hover) {

--- a/data/style.css
+++ b/data/style.css
@@ -14,6 +14,15 @@
   border-radius: 4px;
 }
 
+.now-playing {
+  background-color: alpha(@accent_bg_color, 0.1);
+}
+
+.now-playing .title-4 {
+  color: @accent_color;
+  font-weight: bold;
+}
+
 .card-bg {
   transition: opacity 0.1s ease-in-out;
   transition: background-color 0.1s ease-in-out;
@@ -64,10 +73,10 @@
 }
 
 .explicit-label {
-  padding: 0px;
-  padding-left: 3px;
-  padding-right: 3px;
-  background-color: var(--popover-shade-color);
+  padding: 1px 5px;
+  font-weight: bold;
+  color: alpha(@window_fg_color, 0.7);
+  background-color: alpha(@window_fg_color, 0.15);
   border-radius: 4px;
 }
 

--- a/data/ui/pages_ui/tracks_list_template.blp
+++ b/data/ui/pages_ui/tracks_list_template.blp
@@ -203,6 +203,8 @@ Box _main {
           "title-3",
         ]
 
+        wrap: true;
+        wrap-mode: word_char;
         ellipsize: end;
         vexpand: true;
         lines: 2;

--- a/data/ui/widgets/generic_track_widget.blp
+++ b/data/ui/widgets/generic_track_widget.blp
@@ -21,33 +21,17 @@ template $HTGenericTrackWidget: ListBoxRow {
       margin-start: 6;
       margin-end: 6;
 
-      Stack album_stack {
-        transition-type: none;
-        hhomogeneous: true;
-        vhomogeneous: true;
-        width-request: 44;
+      Image image {
+        pixel-size: 44;
+        icon-name: "emblem-music-symbolic";
+        overflow: hidden;
         margin-end: 12;
         margin-bottom: 6;
         margin-top: 6;
 
-        Image image {
-          pixel-size: 44;
-          icon-name: "emblem-music-symbolic";
-          overflow: hidden;
-
-          styles [
-            "small-image",
-          ]
-        }
-
-        Image now_playing_indicator {
-          icon-name: "media-playback-start-symbolic";
-          pixel-size: 24;
-
-          styles [
-            "small-image",
-          ]
-        }
+        styles [
+          "small-image",
+        ]
       }
 
       Grid _grid {

--- a/data/ui/window.blp
+++ b/data/ui/window.blp
@@ -708,6 +708,10 @@ template $HighTideWindow: Adw.ApplicationWindow {
           title-widget: Adw.ViewSwitcher {
             stack: sidebar_stack;
             policy: wide;
+
+            styles [
+              "player-view-switcher",
+            ]
           };
         }
       }

--- a/src/lib/utils.py
+++ b/src/lib/utils.py
@@ -459,6 +459,26 @@ def get_type(item: Any) -> str:
         return "playlist"
 
 
+def push_page(tag: str, page_factory) -> None:
+    """Push a page, reusing it if one with the same tag is already open.
+
+    If a page with the given tag is in the navigation stack, pop back to it
+    instead of pushing a duplicate. The tag should be unique per entity
+    (e.g. "album-123") so the same entity reuses one page however it's opened.
+
+    Args:
+        tag: A unique tag identifying the page (type and id)
+        page_factory: A callable that builds and returns the page to push
+    """
+    if navigation_view.find_page(tag):
+        navigation_view.pop_to_tag(tag)
+        return
+
+    page = page_factory()
+    page.set_tag(tag)
+    navigation_view.push(page)
+
+
 def open_uri(label: str, uri: str) -> bool:
     """Open a URI by navigating to the appropriate page in the application.
 
@@ -470,11 +490,11 @@ def open_uri(label: str, uri: str) -> bool:
 
     match uri_parts[0]:
         case "artist":
-            page = HTArtistPage.new_from_id(uri_parts[1]).load()
-            navigation_view.push(page)
+            id = uri_parts[1]
+            push_page(f"artist-{id}", lambda: HTArtistPage.new_from_id(id).load())
         case "album":
-            page = HTAlbumPage.new_from_id(uri_parts[1]).load()
-            navigation_view.push(page)
+            id = uri_parts[1]
+            push_page(f"album-{id}", lambda: HTAlbumPage.new_from_id(id).load())
 
     # TODO implement the rest?
     return True
@@ -499,19 +519,24 @@ def open_tidal_uri(uri: str) -> None:
 
     match content_type:
         case "artist":
-            page = HTArtistPage.new_from_id(content_id).load()
-            navigation_view.push(page)
+            push_page(
+                f"artist-{content_id}",
+                lambda: HTArtistPage.new_from_id(content_id).load(),
+            )
         case "album":
-            page = HTAlbumPage.new_from_id(content_id).load()
-            navigation_view.push(page)
+            push_page(
+                f"album-{content_id}",
+                lambda: HTAlbumPage.new_from_id(content_id).load(),
+            )
         case "track":
             threading.Thread(target=th_play_track, args=(content_id,)).start()
         case "mix":
-            page = HTMixPage(content_id).load()
-            navigation_view.push(page)
+            push_page(f"mix-{content_id}", lambda: HTMixPage(content_id).load())
         case "playlist":
-            page = HTPlaylistPage(content_id).load()
-            navigation_view.push(page)
+            push_page(
+                f"playlist-{content_id}",
+                lambda: HTPlaylistPage(content_id).load(),
+            )
         case _:
             logger.warning(f"Unsupported content type: {content_type}")
             return False

--- a/src/widgets/generic_track_widget.py
+++ b/src/widgets/generic_track_widget.py
@@ -46,8 +46,6 @@ class HTGenericTrackWidget(Gtk.ListBoxRow, IDisconnectable):
     __gtype_name__ = "HTGenericTrackWidget"
 
     image = Gtk.Template.Child()
-    now_playing_indicator = Gtk.Template.Child()
-    album_stack = Gtk.Template.Child()
     track_title_label = Gtk.Template.Child()
     track_duration_label = Gtk.Template.Child()
     playlists_submenu = Gtk.Template.Child()
@@ -142,10 +140,10 @@ class HTGenericTrackWidget(Gtk.ListBoxRow, IDisconnectable):
             utils.player_object.playing_track is not None
             and self.track.id == utils.player_object.playing_track.id
         )
-        if is_now and utils.player_object.playing:
-            self.album_stack.set_visible_child(self.now_playing_indicator)
+        if is_now:
+            self.add_css_class("now-playing")
         else:
-            self.album_stack.set_visible_child(self.image)
+            self.remove_css_class("now-playing")
 
     def _on_menu_activate(self, *args):
         if self.menu_activated:

--- a/src/window.py
+++ b/src/window.py
@@ -765,38 +765,44 @@ class HighTideWindow(Adw.ApplicationWindow):
     def on_push_artist_page(self, action, parameter):
         if parameter.get_string() == "":
             return
-        page = HTArtistPage.new_from_id(parameter.get_string()).load()
-        self.navigation_view.push(page)
+        id = parameter.get_string()
+        utils.push_page(f"artist-{id}", lambda: HTArtistPage.new_from_id(id).load())
 
     def on_push_album_page(self, action, parameter):
         if parameter.get_string() == "":
             return
-        page = HTAlbumPage.new_from_id(parameter.get_string()).load()
-        self.navigation_view.push(page)
+        id = parameter.get_string()
+        utils.push_page(f"album-{id}", lambda: HTAlbumPage.new_from_id(id).load())
 
     def on_push_playlist_page(self, action, parameter):
         if parameter.get_string() == "":
             return
-        page = HTPlaylistPage.new_from_id(parameter.get_string()).load()
-        self.navigation_view.push(page)
+        id = parameter.get_string()
+        utils.push_page(
+            f"playlist-{id}", lambda: HTPlaylistPage.new_from_id(id).load()
+        )
 
     def on_push_mix_page(self, action, parameter):
         if parameter.get_string() == "":
             return
-        page = HTMixPage.new_from_id(parameter.get_string()).load()
-        self.navigation_view.push(page)
+        id = parameter.get_string()
+        utils.push_page(f"mix-{id}", lambda: HTMixPage.new_from_id(id).load())
 
     def on_push_track_radio_page(self, action, parameter):
         if parameter.get_string() == "":
             return
-        page = HTMixPage.new_from_track(parameter.get_string()).load()
-        self.navigation_view.push(page)
+        id = parameter.get_string()
+        utils.push_page(
+            f"track-radio-{id}", lambda: HTMixPage.new_from_track(id).load()
+        )
 
     def on_push_artist_radio_page(self, action, parameter):
         if parameter.get_string() == "":
             return
-        page = HTMixPage.new_from_artist(parameter.get_string()).load()
-        self.navigation_view.push(page)
+        id = parameter.get_string()
+        utils.push_page(
+            f"artist-radio-{id}", lambda: HTMixPage.new_from_artist(id).load()
+        )
 
     #
     #


### PR DESCRIPTION
- reuse already open pages instead of pushing duplicates (go to album,
  track radio, artist, and uri/link handlers)
- highlight the currently playing track with an accent title instead of
  hiding the cover behind an icon
- use libadwaita @ named colors instead of var() so the stylesheet
  actually applies (card backgrounds, row striping, lyrics, explicit
  badge, etc)
- give home cards a background so they dont blend into the page
- space out the player view switcher icons from their labels
- wrap long descriptions so they dont overlap the track count label