### PR TITLE
Add selectable accessible text sizes

### DIFF
--- a/data/io.github.nokse22.high-tide.gschema.xml
+++ b/data/io.github.nokse22.high-tide.gschema.xml
@@ -10,6 +10,10 @@
 	  <key name="quality" type="i">
       <default>2</default>
     </key>
+    <key name="text-size" type="i">
+      <range min="0" max="3"/>
+      <default>0</default>
+    </key>
 	  <key name="last-playing-index" type="i">
       <default>-1</default>
     </key>

--- a/data/style.css
+++ b/data/style.css
@@ -110,6 +110,7 @@
 }
 
 .tracks-list-box row {
+  min-height: 3.5em;
   border-radius: 12px;
   background-color: transparent;
   transition: background-color 0.1s ease-in-out;

--- a/data/ui/pages_ui/artist_page_template.blp
+++ b/data/ui/pages_ui/artist_page_template.blp
@@ -9,7 +9,7 @@ Box _main {
     height-request: 150;
 
     Adw.Breakpoint {
-      condition ("max-width: 500px")
+      condition ("max-width: 500sp")
 
       setters {
         multi_layout_view.layout-name: "vertical";
@@ -154,7 +154,9 @@ Box _main {
         ]
 
         ellipsize: end;
+        lines: 2;
         vexpand: true;
+        wrap: true;
         xalign: 0.0;
         yalign: 0.0;
       }
@@ -166,7 +168,9 @@ Box _main {
         ]
 
         ellipsize: end;
+        lines: 2;
         vexpand: true;
+        wrap: true;
         xalign: 0.0;
         yalign: 0.0;
       }

--- a/data/ui/pages_ui/tracks_list_template.blp
+++ b/data/ui/pages_ui/tracks_list_template.blp
@@ -11,7 +11,7 @@ Box _main {
     vexpand-set: true;
 
     Adw.Breakpoint {
-      condition ("max-width: 500px")
+      condition ("max-width: 500sp")
 
       setters {
         multi_layout_view.layout-name: "vertical";
@@ -192,7 +192,9 @@ Box _main {
         ]
 
         ellipsize: end;
+        lines: 2;
         vexpand: true;
+        wrap: true;
         xalign: 0.0;
       }
 
@@ -206,6 +208,7 @@ Box _main {
         ellipsize: end;
         vexpand: true;
         lines: 2;
+        wrap: true;
         xalign: 0.0;
       }
 
@@ -217,7 +220,8 @@ Box _main {
 
         ellipsize: end;
         vexpand: true;
-        lines: 1;
+        lines: 2;
+        wrap: true;
         xalign: 0.0;
       }
 

--- a/data/ui/preferences.blp
+++ b/data/ui/preferences.blp
@@ -4,6 +4,23 @@ using Adw 1;
 Adw.PreferencesDialog _preference_window {
   Adw.PreferencesPage {
     Adw.PreferencesGroup {
+      title: _("Accessibility");
+      Adw.ComboRow _text_size_row {
+        model: StringList {
+          strings [
+            _("Default (100%)"),
+            _("Large (125%)"),
+            _("Extra Large (150%)"),
+            _("2XL (200%)"),
+          ]
+        };
+
+        title: _("Text Size");
+        subtitle: _("Adjust the size of text throughout the app");
+      }
+    }
+
+    Adw.PreferencesGroup {
       title: _("Audio");
       Adw.ComboRow _quality_row {
         model: StringList {

--- a/data/ui/widgets/card_widget.blp
+++ b/data/ui/widgets/card_widget.blp
@@ -41,6 +41,8 @@ template $HTCardWidget: Adw.BreakpointBin {
       max-width-chars: 13;
       xalign: 0;
       ellipsize: end;
+      lines: 2;
+      wrap: true;
     }
 
     Box details_box {
@@ -52,11 +54,15 @@ template $HTCardWidget: Adw.BreakpointBin {
         max-width-chars: 16;
         xalign: 0;
         ellipsize: end;
+        lines: 2;
+        wrap: true;
       }
 
       $HTLinkLabelWidget track_artist_label {
         ellipsize: 'end';
+        lines: 2;
         max-width-chars: 16;
+        wrap: true;
         xalign: '0';
       }
     }

--- a/data/ui/widgets/carousel_widget.blp
+++ b/data/ui/widgets/carousel_widget.blp
@@ -19,7 +19,9 @@ template $HTCarouselWidget: Box {
 
       ellipsize: end;
       hexpand: true;
+      lines: 2;
       margin-start: 6;
+      wrap: true;
       xalign: -0.0;
     }
 

--- a/data/ui/widgets/generic_track_widget.blp
+++ b/data/ui/widgets/generic_track_widget.blp
@@ -9,7 +9,7 @@ template $HTGenericTrackWidget: ListBoxRow {
     height-request: 56;
 
     Adw.Breakpoint {
-      condition ("max-width: 600px")
+      condition ("max-width: 600sp")
 
       setters {
         _grid.visible: false;
@@ -59,6 +59,8 @@ template $HTGenericTrackWidget: ListBoxRow {
         $HTLinkLabelWidget track_album_label {
           xalign: "0";
           ellipsize: "3";
+          lines: 2;
+          wrap: true;
 
           layout {
             column: "5";
@@ -81,7 +83,9 @@ template $HTGenericTrackWidget: ListBoxRow {
 
             ellipsize: end;
             label: _("Title");
+            lines: 2;
             vexpand: true;
+            wrap: true;
             xalign: 0.0;
           }
 
@@ -101,6 +105,8 @@ template $HTGenericTrackWidget: ListBoxRow {
         $HTLinkLabelWidget artist_label {
           xalign: "0";
           ellipsize: "3";
+          lines: 2;
+          wrap: true;
 
           layout {
             column: "3";
@@ -124,7 +130,9 @@ template $HTGenericTrackWidget: ListBoxRow {
             ]
 
             ellipsize: end;
+            lines: 2;
             vexpand: true;
+            wrap: true;
             xalign: 0.0;
           }
 
@@ -145,8 +153,10 @@ template $HTGenericTrackWidget: ListBoxRow {
           xalign: "0";
           use-markup: "true";
           ellipsize: "3";
+          lines: 2;
           margin-bottom: "6";
           label: bind artist_label.label;
+          wrap: true;
         }
       }
 

--- a/data/ui/widgets/shortcut_widget.blp
+++ b/data/ui/widgets/shortcut_widget.blp
@@ -24,7 +24,9 @@ template $HTShorcutWidget: Gtk.FlowBoxChild {
       Label title_label {
         ellipsize: end;
         hexpand: true;
+        lines: 2;
         max-width-chars: 20;
+        wrap: true;
         xalign: 0.0;
       }
 
@@ -35,8 +37,10 @@ template $HTShorcutWidget: Gtk.FlowBoxChild {
 
         ellipsize: end;
         // visible: false;
+        lines: 2;
         max-width-chars: 20;
         hexpand: true;
+        wrap: true;
         xalign: 0.0;
       }
     }

--- a/data/ui/widgets/top_hit_widget.blp
+++ b/data/ui/widgets/top_hit_widget.blp
@@ -60,7 +60,9 @@ template $HTTopHitWidget: Box {
             ]
 
             ellipsize: end;
+            lines: 2;
             vexpand: true;
+            wrap: true;
             xalign: 0.0;
           }
 

--- a/data/ui/widgets/tracks_list_widget.blp
+++ b/data/ui/widgets/tracks_list_widget.blp
@@ -16,7 +16,9 @@ template $HTTracksListWidget: Box {
 
       ellipsize: end;
       hexpand: true;
+      lines: 2;
       margin-start: 6;
+      wrap: true;
       xalign: -0.0;
     }
 

--- a/data/ui/window.blp
+++ b/data/ui/window.blp
@@ -463,12 +463,17 @@ template $HighTideWindow: Adw.ApplicationWindow {
                   }
 
                   Box {
-                    halign: center;
+                    hexpand: true;
                     spacing: 6;
 
                     Label song_title_label {
                       label: _("No Song");
                       ellipsize: end;
+                      hexpand: true;
+                      justify: center;
+                      lines: 2;
+                      wrap: true;
+                      xalign: 0.5;
 
                       styles [
                         "title-1",
@@ -491,6 +496,10 @@ template $HighTideWindow: Adw.ApplicationWindow {
                   $HTLinkLabelWidget artist_label {
                     label: _("Nobody");
                     ellipsize: "end";
+                    justify: center;
+                    lines: 2;
+                    wrap: true;
+                    xalign: 0.5;
 
                     styles [
                       "title-3",

--- a/po/POTFILES
+++ b/po/POTFILES
@@ -1,4 +1,4 @@
-data/gtk/help-overlay.blp
+data/shortcuts-dialog.blp
 data/ui/card_template.blp
 data/ui/detailed_track_listing.blp
 data/ui/login.blp

--- a/po/high-tide.pot
+++ b/po/high-tide.pot
@@ -1,81 +1,87 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
+# This file is distributed under the same license as the high-tide package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
+"Project-Id-Version: high-tide\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-08-22 20:42+0200\n"
+"POT-Creation-Date: 2026-07-14 19:58-0400\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "Language: \n"
 "MIME-Version: 1.0\n"
-"Content-Type: text/plain; charset=CHARSET\n"
+"Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: data/gtk/help-overlay.blp:11
-msgctxt "shortcut window"
-msgid "General"
-msgstr ""
-
-#: data/gtk/help-overlay.blp:14
+#: data/shortcuts-dialog.blp:7
 msgctxt "shortcut window"
 msgid "Show Shortcuts"
 msgstr ""
 
-#: data/gtk/help-overlay.blp:19
+#: data/shortcuts-dialog.blp:12
 msgctxt "shortcut window"
 msgid "Edit preferences"
 msgstr ""
 
-#: data/gtk/help-overlay.blp:24
+#: data/shortcuts-dialog.blp:17
 msgctxt "shortcut window"
 msgid "Quit"
 msgstr ""
 
-#: data/ui/detailed_track_listing.blp:46 src/widgets/top_hit_widget.py:131
+#: data/ui/detailed_track_listing.blp:46
+#: data/ui/pages_ui/tracks_list_template.blp:110
+#: src/widgets/top_hit_widget.py:141
 msgid "Album"
 msgstr ""
 
 #: data/ui/detailed_track_listing.blp:62 data/ui/detailed_track_listing.blp:93
-#: data/ui/widgets/generic_track_widget.blp:68
+#: data/ui/pages_ui/tracks_list_template.blp:108
+#: data/ui/widgets/generic_track_widget.blp:85
 msgid "Title"
 msgstr ""
 
 #: data/ui/detailed_track_listing.blp:137
-#: data/ui/detailed_track_listing.blp:162 data/ui/window.blp:528
+#: data/ui/detailed_track_listing.blp:162 data/ui/window.blp:538
 msgid "Go to track radio"
 msgstr ""
 
 #: data/ui/detailed_track_listing.blp:142
 #: data/ui/detailed_track_listing.blp:167
-#: data/ui/widgets/generic_track_widget.blp:160
+#: data/ui/widgets/generic_track_widget.blp:185
 msgid "Play next"
 msgstr ""
 
 #: data/ui/detailed_track_listing.blp:147
 #: data/ui/detailed_track_listing.blp:177
-#: data/ui/widgets/generic_track_widget.blp:170
+#: data/ui/widgets/generic_track_widget.blp:195
 msgid "Add to my collection"
 msgstr ""
 
 #: data/ui/detailed_track_listing.blp:172
-#: data/ui/widgets/generic_track_widget.blp:165
+#: data/ui/widgets/generic_track_widget.blp:190
 msgid "Add to queue"
 msgstr ""
 
-#: data/ui/login.blp:5
+#: data/ui/login.blp:5 data/ui/login.blp:59
 msgid "Log In"
 msgstr ""
 
-#: data/ui/login.blp:23
+#: data/ui/login.blp:22
 msgid ""
-"Go to this website and login with your account, if it asks for a code insert "
-"the code provided below."
+"Sign in on Tidal. Your browser will redirect to a \"Page not found\" — "
+"that's expected. Copy the full URL from the address bar and paste it below."
+msgstr ""
+
+#: data/ui/login.blp:29
+msgid "Open Tidal Login"
+msgstr ""
+
+#: data/ui/login.blp:40
+msgid "Paste redirected URL here"
 msgstr ""
 
 #: data/ui/new_playlist.blp:29
@@ -91,72 +97,100 @@ msgid "Create"
 msgstr ""
 
 #: data/ui/preferences.blp:7
-msgid "Audio"
+msgid "Accessibility"
 msgstr ""
 
 #: data/ui/preferences.blp:11
-msgid "Low 96k"
+msgid "Default (100%)"
 msgstr ""
 
 #: data/ui/preferences.blp:12
-msgid "High 320k"
+msgid "Large (125%)"
 msgstr ""
 
 #: data/ui/preferences.blp:13
-msgid "Lossless"
+msgid "Extra Large (150%)"
 msgstr ""
 
 #: data/ui/preferences.blp:14
-msgid "Hi-res Lossless"
+msgid "2XL (200%)"
 msgstr ""
 
 #: data/ui/preferences.blp:18
+msgid "Text Size"
+msgstr ""
+
+#: data/ui/preferences.blp:19
+msgid "Adjust the size of text throughout the app"
+msgstr ""
+
+#: data/ui/preferences.blp:24
+msgid "Audio"
+msgstr ""
+
+#: data/ui/preferences.blp:28
+msgid "Low 96k"
+msgstr ""
+
+#: data/ui/preferences.blp:29
+msgid "High 320k"
+msgstr ""
+
+#: data/ui/preferences.blp:30
+msgid "Lossless"
+msgstr ""
+
+#: data/ui/preferences.blp:31
+msgid "Hi-res Lossless"
+msgstr ""
+
+#: data/ui/preferences.blp:35
 msgid "Quality"
 msgstr ""
 
-#: data/ui/preferences.blp:23
+#: data/ui/preferences.blp:40
 msgid "Automatic"
 msgstr ""
 
-#: data/ui/preferences.blp:32
+#: data/ui/preferences.blp:49
 msgid "Preferred Audio Sink"
 msgstr ""
 
-#: data/ui/preferences.blp:33
+#: data/ui/preferences.blp:50
 msgid ""
 "Gapless playback is disabled for the native Pipewire Sink due to a bug. Use "
 "'Automatic' for gapless playback."
 msgstr ""
 
-#: data/ui/preferences.blp:36
+#: data/ui/preferences.blp:53
 msgid "ALSA Device"
 msgstr ""
 
-#: data/ui/preferences.blp:37
+#: data/ui/preferences.blp:54
 msgid "Device used for exclusive ALSA access"
 msgstr ""
 
-#: data/ui/preferences.blp:40
+#: data/ui/preferences.blp:57
 msgid "Normalize volume"
 msgstr ""
 
-#: data/ui/preferences.blp:45
+#: data/ui/preferences.blp:62
 msgid "App"
 msgstr ""
 
-#: data/ui/preferences.blp:47
+#: data/ui/preferences.blp:64
 msgid "Run in the background"
 msgstr ""
 
-#: data/ui/preferences.blp:50
+#: data/ui/preferences.blp:67
 msgid "Use quadratic volume control"
 msgstr ""
 
-#: data/ui/preferences.blp:53
+#: data/ui/preferences.blp:70
 msgid "Display animated covers"
 msgstr ""
 
-#: data/ui/preferences.blp:56
+#: data/ui/preferences.blp:73
 msgid "Enable Discord Rich Presence"
 msgstr ""
 
@@ -174,80 +208,80 @@ msgid ""
 "Flatpak make sure to remove the old version with this command:"
 msgstr ""
 
-#: data/ui/window.blp:18
+#: data/ui/window.blp:19
 msgid "I understood"
 msgstr ""
 
-#: data/ui/window.blp:158 data/ui/window.blp:394 data/ui/window.blp:639
+#: data/ui/window.blp:159 data/ui/window.blp:395 data/ui/window.blp:649
 msgid "Play/Pause"
 msgstr ""
 
-#: data/ui/window.blp:169 data/ui/window.blp:406 data/ui/window.blp:652
+#: data/ui/window.blp:170 data/ui/window.blp:407 data/ui/window.blp:662
 msgid "Skip Forward"
 msgstr ""
 
-#: data/ui/window.blp:214 src/pages/page.py:73
+#: data/ui/window.blp:215 src/pages/page.py:74
 msgid "Loading..."
 msgstr ""
 
-#: data/ui/window.blp:240
+#: data/ui/window.blp:241
 msgid "Home"
 msgstr ""
 
-#: data/ui/window.blp:265 src/pages/explore_page.py:49
+#: data/ui/window.blp:266 src/pages/explore_page.py:51
 msgid "Explore"
 msgstr ""
 
-#: data/ui/window.blp:290 src/pages/collection_page.py:35
+#: data/ui/window.blp:291 src/pages/collection_page.py:35
 msgid "Collection"
 msgstr ""
 
-#: data/ui/window.blp:469
+#: data/ui/window.blp:470
 msgid "No Song"
 msgstr ""
 
-#: data/ui/window.blp:491
+#: data/ui/window.blp:497
 msgid "Nobody"
 msgstr ""
 
-#: data/ui/window.blp:516
+#: data/ui/window.blp:526
 msgid "Add/Remove from favorites"
 msgstr ""
 
-#: data/ui/window.blp:540
+#: data/ui/window.blp:550
 msgid "Go to album"
 msgstr ""
 
-#: data/ui/window.blp:552
+#: data/ui/window.blp:562
 msgid "Copy Share Link"
 msgstr ""
 
-#: data/ui/window.blp:614
+#: data/ui/window.blp:624
 msgid "Toggle Shuffle"
 msgstr ""
 
-#: data/ui/window.blp:627
+#: data/ui/window.blp:637
 msgid "Skip Backward"
 msgstr ""
 
-#: data/ui/window.blp:680
+#: data/ui/window.blp:690
 msgid "Player"
 msgstr ""
 
-#: data/ui/window.blp:690 data/ui/widgets/lyrics_widget.blp:22
+#: data/ui/window.blp:700 data/ui/widgets/lyrics_widget.blp:22
 msgid "Lyrics"
 msgstr ""
 
-#: data/ui/window.blp:700 data/ui/widgets/queue_widget.blp:58
+#: data/ui/window.blp:710 data/ui/widgets/queue_widget.blp:58
 msgid "Queue"
 msgstr ""
 
-#: data/ui/pages_ui/artist_page_template.blp:182
+#: data/ui/pages_ui/artist_page_template.blp:186
 msgid "Radio"
 msgstr ""
 
-#: data/ui/pages_ui/artist_page_template.blp:196
-#: data/ui/pages_ui/tracks_list_template.blp:205
+#: data/ui/pages_ui/artist_page_template.blp:200
+#: data/ui/pages_ui/tracks_list_template.blp:236
 msgid "Copy Share URL"
 msgstr ""
 
@@ -275,11 +309,29 @@ msgstr ""
 msgid "_Quit"
 msgstr ""
 
-#: data/ui/widgets/generic_track_widget.blp:175
+#: data/ui/pages_ui/tracks_list_template.blp:107
+msgid "Sort by"
+msgstr ""
+
+#: data/ui/pages_ui/tracks_list_template.blp:109 src/pages/artist_page.py:149
+#: src/widgets/card_widget.py:152 src/widgets/top_hit_widget.py:196
+msgid "Artist"
+msgstr ""
+
+#: data/ui/pages_ui/tracks_list_template.blp:111
+msgid "Duration"
+msgstr ""
+
+#: data/ui/widgets/carousel_widget.blp:29
+#: data/ui/widgets/tracks_list_widget.blp:26
+msgid "More"
+msgstr ""
+
+#: data/ui/widgets/generic_track_widget.blp:200
 msgid "Copy share url"
 msgstr ""
 
-#: data/ui/widgets/generic_track_widget.blp:179
+#: data/ui/widgets/generic_track_widget.blp:204
 msgid "Add to a playlist"
 msgstr ""
 
@@ -306,6 +358,18 @@ msgstr ""
 #: data/io.github.nokse22.high-tide.desktop.in:2
 #: data/io.github.nokse22.high-tide.appdata.xml.in:9
 msgid "High Tide"
+msgstr ""
+
+#: data/io.github.nokse22.high-tide.desktop.in:3
+msgid "Libadwaita TIDAL client for Linux"
+msgstr ""
+
+#: data/io.github.nokse22.high-tide.desktop.in:4
+msgid "TIDAL Music Client"
+msgstr ""
+
+#: data/io.github.nokse22.high-tide.desktop.in:12
+msgid "music;audio;streaming;tidal;player;hi-fi;lossless;"
 msgstr ""
 
 #: data/io.github.nokse22.high-tide.appdata.xml.in:10
@@ -337,41 +401,32 @@ msgstr ""
 msgid "High Tide in a small window format playing `Light My Fire` by The Doors"
 msgstr ""
 
-#: src/pages/album_page.py:60
+#: src/pages/album_page.py:46
 msgid "Unknown"
 msgstr ""
 
-#: src/pages/album_page.py:64 src/pages/playlist_page.py:78
-msgid "{} tracks ({})"
-msgstr ""
-
-#: src/pages/artist_page.py:91 src/widgets/card_widget.py:151
-#: src/widgets/top_hit_widget.py:179
-msgid "Artist"
-msgstr ""
-
-#: src/pages/artist_page.py:94
+#: src/pages/artist_page.py:152
 msgid "Top Tracks"
 msgstr ""
 
-#: src/pages/artist_page.py:97 src/pages/collection_page.py:39
-#: src/pages/search_page.py:57
+#: src/pages/artist_page.py:155 src/pages/collection_page.py:39
+#: src/pages/search_page.py:55
 msgid "Albums"
 msgstr ""
 
-#: src/pages/artist_page.py:100
+#: src/pages/artist_page.py:158
 msgid "EP & Singles"
 msgstr ""
 
-#: src/pages/artist_page.py:104
+#: src/pages/artist_page.py:162
 msgid "Appears On"
 msgstr ""
 
-#: src/pages/artist_page.py:107
+#: src/pages/artist_page.py:165
 msgid "Similar Artists"
 msgstr ""
 
-#: src/pages/artist_page.py:130
+#: src/pages/artist_page.py:188
 msgid "Bio"
 msgstr ""
 
@@ -379,86 +434,98 @@ msgstr ""
 msgid "My Mixes and Radios"
 msgstr ""
 
-#: src/pages/collection_page.py:38 src/pages/search_page.py:58
+#: src/pages/collection_page.py:38 src/pages/search_page.py:56
 msgid "Playlists"
 msgstr ""
 
-#: src/pages/collection_page.py:40 src/pages/search_page.py:59
+#: src/pages/collection_page.py:40 src/pages/search_page.py:57
 msgid "Tracks"
 msgstr ""
 
-#: src/pages/collection_page.py:41 src/pages/search_page.py:56
+#: src/pages/collection_page.py:41 src/pages/search_page.py:54
 msgid "Artists"
 msgstr ""
 
-#: src/pages/not_logged_in_page.py:38
+#: src/pages/not_logged_in_page.py:37
 msgid "Login"
 msgstr ""
 
-#: src/pages/not_logged_in_page.py:45
+#: src/pages/not_logged_in_page.py:44
 msgid "Login first"
 msgstr ""
 
-#: src/pages/not_logged_in_page.py:47
+#: src/pages/not_logged_in_page.py:46
 msgid "To be able to use this app, you need to login with your TIDAL account."
 msgstr ""
 
-#: src/pages/playlist_page.py:75
+#: src/pages/playlist_page.py:54
+#, python-brace-format
 msgid "by {}"
 msgstr ""
 
-#: src/widgets/card_widget.py:108
+#: src/widgets/card_widget.py:109
+#, python-brace-format
 msgid "Track by {}"
 msgstr ""
 
-#: src/widgets/card_widget.py:143 src/widgets/top_hit_widget.py:159
+#: src/widgets/card_widget.py:144 src/widgets/top_hit_widget.py:172
+#, python-brace-format
 msgid "By {}"
 msgstr ""
 
-#: src/widgets/top_hit_widget.py:88
+#: src/widgets/top_hit_widget.py:92
 msgid "Track"
 msgstr ""
 
-#: src/widgets/top_hit_widget.py:108
+#: src/widgets/top_hit_widget.py:114
 msgid "Mix"
 msgstr ""
 
-#: src/main.py:107
+#: src/login.py:80
+msgid "Login was rejected by Tidal."
+msgstr ""
+
+#: src/login.py:88
+#, python-brace-format
+msgid "Login failed: {error}"
+msgstr ""
+
+#: src/main.py:127
 msgid "Donate with Ko-Fi"
 msgstr ""
 
-#: src/main.py:108
+#: src/main.py:128
 msgid "Donate with Github"
 msgstr ""
 
-#: src/window.py:231
+#: src/window.py:216
 msgid "Playing Music"
 msgstr ""
 
-#: src/lib/utils.py:102
+#: src/lib/utils.py:106 src/lib/utils.py:152
 msgid "Default"
 msgstr ""
 
-#: src/lib/utils.py:300
+#: src/lib/utils.py:367
 msgid "Successfully added to my collection"
 msgstr ""
 
-#: src/lib/utils.py:303
+#: src/lib/utils.py:370
 msgid "Failed to add item to my collection"
 msgstr ""
 
-#: src/lib/utils.py:329
+#: src/lib/utils.py:396
 msgid "Successfully removed from my collection"
 msgstr ""
 
-#: src/lib/utils.py:331
+#: src/lib/utils.py:398
 msgid "Failed to remove item from my collection"
 msgstr ""
 
-#: src/lib/utils.py:371
+#: src/lib/utils.py:438
 msgid "Copied share URL in the clipboard"
 msgstr ""
 
-#: src/lib/player_object.py:268
+#: src/lib/player_object.py:273
 msgid "ALSA Audio Device is not available"
 msgstr ""

--- a/src/main.py
+++ b/src/main.py
@@ -19,13 +19,17 @@
 
 import sys
 from gettext import gettext as _
-from typing import Any, Callable, List
+from typing import Any, Callable, List, cast
 
-from gi.repository import Adw, Gio, Gtk
+from gi.repository import Adw, Gio, Gtk  # pyright: ignore[reportAttributeAccessIssue]
 
 from .lib import utils
 from .lib.player_object import AudioSink
 from .window import HighTideWindow
+
+
+DEFAULT_FONT_DPI = 96 * 1024
+TEXT_SIZE_SCALES = (1.0, 1.25, 1.5, 2.0)
 
 
 class HighTideApplication(Adw.Application):
@@ -52,22 +56,35 @@ class HighTideApplication(Adw.Application):
         utils.setup_logging()
 
         self.settings: Gio.Settings = Gio.Settings.new("io.github.nokse22.high-tide")
+        self.gtk_settings: Gtk.Settings | None = Gtk.Settings.get_default()
+        self.base_font_dpi = DEFAULT_FONT_DPI
+        if self.gtk_settings:
+            configured_dpi = self.gtk_settings.get_property("gtk-xft-dpi")
+            if configured_dpi > 0:
+                self.base_font_dpi = configured_dpi
+
+        self.settings.connect("changed::text-size", self.on_text_size_setting_changed)
+        self.apply_text_size()
 
         self.preferences: Gtk.Window | None = None
+        self.win: HighTideWindow
 
         self.alsa_devices = utils.get_alsa_devices()
 
     def do_open(self, files: List[Gio.File], n_files: int, hint: str) -> None:
-        self.win: HighTideWindow | None = self.props.active_window
-        if not self.win:
+        win = cast(HighTideWindow | None, self.props.active_window)
+        if win is None:
             self.do_activate()
+            win = self.win
+        else:
+            self.win = win
 
         uri: str = files[0].get_uri()
         if uri:
-            if self.win.is_logged_in:
+            if win.is_logged_in:
                 utils.open_tidal_uri(uri)
             else:
-                self.win.queued_uri = uri
+                win.queued_uri = cast(Any, uri)
 
     def on_login_action(self, *args) -> None:
         """Handle the login action by initiating a new login process."""
@@ -79,11 +96,12 @@ class HighTideApplication(Adw.Application):
 
     def do_activate(self) -> None:
         """Activate the application by creating and presenting the main window."""
-        self.win: HighTideWindow | None = self.props.active_window
-        if not self.win:
-            self.win = HighTideWindow(application=self)
+        win = cast(HighTideWindow | None, self.props.active_window)
+        if win is None:
+            win = HighTideWindow(application=self)
 
-        self.win.present()
+        self.win = win
+        win.present()
 
     def on_about_action(self, widget: Any, *args) -> None:
         """Display the about dialog with application information"""
@@ -117,6 +135,13 @@ class HighTideApplication(Adw.Application):
         if not self.preferences:
             builder: Gtk.Builder = Gtk.Builder.new_from_resource(
                 "/io/github/nokse22/high-tide/ui/preferences.ui"
+            )
+
+            builder.get_object("_text_size_row").set_selected(
+                self.settings.get_int("text-size")
+            )
+            builder.get_object("_text_size_row").connect(
+                "notify::selected", self.on_text_size_changed
             )
 
             builder.get_object("_quality_row").set_selected(
@@ -216,7 +241,28 @@ class HighTideApplication(Adw.Application):
 
             self.preferences = builder.get_object("_preference_window")
 
-        self.preferences.present(self.win)
+        preferences = self.preferences
+        if preferences:
+            preferences.present(self.win)
+
+    def apply_text_size(self) -> None:
+        """Apply the selected text scale to this GTK process."""
+        if not self.gtk_settings:
+            return
+
+        selected = self.settings.get_int("text-size")
+        scaled_dpi = round(self.base_font_dpi * TEXT_SIZE_SCALES[selected])
+        self.gtk_settings.set_property("gtk-xft-dpi", scaled_dpi)
+
+    def on_text_size_setting_changed(self, *args) -> None:
+        """Apply text size changes made through GSettings."""
+        self.apply_text_size()
+
+    def on_text_size_changed(self, widget: Any, *args) -> None:
+        """Persist the text size selected in preferences."""
+        selected = widget.get_selected()
+        if selected != self.settings.get_int("text-size"):
+            self.settings.set_int("text-size", selected)
 
     def on_quality_changed(self, widget: Any, *args) -> None:
         self.win.select_quality(widget.get_selected())
@@ -248,7 +294,10 @@ class HighTideApplication(Adw.Application):
             self.alsa_row.set_selected(0)
 
     def create_action(
-        self, name: str, callback: Callable, shortcuts: List[str] | None = None
+        self,
+        name: str,
+        callback: Callable[..., Any],
+        shortcuts: List[str] | None = None,
     ) -> None:
         """Create a new application action with optional keyboard shortcuts.
 


### PR DESCRIPTION
## Summary

- add a persistent Accessibility preference with 100%, 125%, 150%, and 200% text-size presets
- apply text scaling immediately and on startup while preserving the user's system font baseline
- use text-scaled `sp` breakpoints and two-line wrapping so metadata and controls remain usable with large text
- update translation sources for the new preference labels

## Validation

- `meson compile -C build`
- `meson test -C build --print-errorlogs`
- strict GSettings schema and Blueprint compilation
- Ruff, formatting, Pyright/LSP, gettext template, and whitespace checks on changed files
- runtime checks for all four scale factors and persistence across processes
- responsive track-row check at 100% and 200% on desktop and narrow widths

Closes #304