### PR TITLE
Fix crash on startup when XDG_CACHE_HOME is not defined

### DIFF
--- a/src/lib/utils.py
+++ b/src/lib/utils.py
@@ -66,6 +66,9 @@ def init() -> None:
     if CACHE_DIR == "" or CACHE_DIR is None or "high-tide" not in CACHE_DIR:
         CACHE_DIR = f"{os.environ.get('HOME')}/.cache/high-tide"
 
+    CACHE_DIR = Path(CACHE_DIR)
+    CACHE_DIR.mkdir(exist_ok=True)
+
     global IMG_DIR
     IMG_DIR = Path(CACHE_DIR, "images")
     IMG_DIR.mkdir(exist_ok=True)


### PR DESCRIPTION
High Tide crashes on systems, where $XDG_CACHE_HOME is not defined.
For some reason it was the case on my NixOS setup. Converting CACHE_DIR to a Path does not seem to introduce any breakage.
Fixes #292 