### PR TITLE
mpris: Fix play/pause flickering

### DIFF
--- a/src/mpris.py
+++ b/src/mpris.py
@@ -287,10 +287,6 @@ class MPRIS(Server):
 
         position = max(0, min(position, duration_us))
 
-        seek_fraction = position / duration_us if duration_us > 0 else 0
-
-        self.player.seek(seek_fraction)
-
         self.PropertiesChanged(
             self.__MPRIS_PLAYER_IFACE,
             {"Position": GLib.Variant("x", int(position))},


### PR DESCRIPTION
VW Head Unit play/pause button flickers as SetPosition also calls Seek which according to the standard means: Pause -> Seek -> Play. Fix it by removing the seek in SetPosition